### PR TITLE
Prevent drag when editing module node

### DIFF
--- a/src/components/ModuleNode.vue
+++ b/src/components/ModuleNode.vue
@@ -4,6 +4,7 @@
     :id="id"
     ref="moduleNode"
     :class="{ selected: selected }"
+    @mousedown.capture="StopDrag"
   >
     <NodeResizer min-width="180" min-height="75" :is-visible="selected" />
 
@@ -245,6 +246,12 @@ async function startEditing(event) {
 
   // Focus the input
   inputRef.value?.focus()
+}
+
+function StopDrag(event) {
+  if (isEditing.value) {
+    event.stopPropagation()
+  }
 }
 
 // This is triggered by pressing Enter or clicking away


### PR DESCRIPTION
Added StopDrag handler to stop drag events from propagating when the node is in editing mode, to prevent accidental drags. 

Resolves #25.