### PR TITLE
Fix layout of module buttons

### DIFF
--- a/src/components/ModuleNode.vue
+++ b/src/components/ModuleNode.vue
@@ -454,9 +454,13 @@ function handleDocumentContextmenu(e) {
   font-size: 18px;
   cursor: help;
 
-  /* Optional: specific Hover effect */
   &:hover {
     color: var(--el-color-warning-dark-2);
   }
 }
+
+.module-button {
+  margin: 0;
+}
+
 </style>


### PR DESCRIPTION
Remove the gap after the third module button on module nodes. 