### PR TITLE
Fix header trimming in import vessel array

### DIFF
--- a/src/utils/import.js
+++ b/src/utils/import.js
@@ -99,7 +99,7 @@ const parseVesselCsv = (file, builderStore = null) => {
     Papa.parse(file, {
       header: true,
       skipEmptyLines: true,
-      trimHeaders: true,
+      transformHeader: (header) => header.trim(),
       transform: (v) => v.trim(),
       complete: (results) => {
         if (


### PR DESCRIPTION
trimHeader function wasn't removing spaces that sometimes appear in circulatory autogen vessel array file headers. I've updated the approach and confirmed it works with the provided test file. Resolves #160. 