### PR TITLE
Temp disable of limited port option selection

### DIFF
--- a/src/components/EditModuleDialog.vue
+++ b/src/components/EditModuleDialog.vue
@@ -182,11 +182,9 @@ function isOptionDisabled(optionName, currentSelection) {
   // 1. It's in the usedOptions Set
   // 2. And it's NOT an option this row already has selected
 
-  // disabling for now as circ auto configs have multiple ports with same variable options, and this logic would prevent that. We can revisit if we want to enforce unique variable options across ports in the future.
-  return //(
-    // usedOptions.value.has(optionName) &&
-    // currentSelection.includes(optionName) === false
-  //)
+  // FIXME: Disabling for now as circ auto configs have multiple ports with same variable options, and this logic would prevent that. We can revisit if we want to enforce unique variable options across ports in the future.
+  // return (usedOptions.value.has(optionName) && currentSelection.includes(optionName) === false)
+  return false
 }
 
 function addPortLabel() {


### PR DESCRIPTION
Circulatory autogen appears to let users have variables assigned to multiple port labels, as not all port labels have to be connected. Disabling the limited port option selection for the tutorial.