### PR TITLE
Add module config getter to builder store

### DIFF
--- a/src/stores/builderStore.js
+++ b/src/stores/builderStore.js
@@ -349,9 +349,7 @@ export const useBuilderStore = defineStore('builder', () => {
 
   function getModuleConfigFromConfigIndex(filename, moduleName, configIndex) {
     const module = getModulesModule(filename, moduleName)
-    return {
-      config: module.configs[configIndex],
-    }
+    return module.configs[configIndex]
   }
 
   function getState() {


### PR DESCRIPTION
Uses data contained in node (filename, component[module]Name, and config index) to easily get config information from the builderStore. 

Resolves #260 