### PR TITLE
Introduce compact module view node

### DIFF
--- a/src/components/ModuleNode.vue
+++ b/src/components/ModuleNode.vue
@@ -613,17 +613,17 @@ function handleDocumentContextmenu(e) {
 }
 
 .button-group {
-  transition: opacity 0.3s ease, visibility 0.3s ease;
+ // transition: opacity 0.3s ease, visibility 0.3s ease;
   opacity: 1;
   visibility: visible;
-  transition-delay: 0.2s; 
+ // transition-delay: 0.2s; 
 }
 
 .module-node.compact-mode .button-group {
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
-  transition-delay: 0s; 
+//  transition-delay: 0s; 
 }
 
 .module-node > .el-card,
@@ -637,11 +637,15 @@ function handleDocumentContextmenu(e) {
   border: 3px solid rgba(0,0,0,0.04);
   display: flex;
   flex-direction: column;
-  transition: border-width 0.3s ease;
+//  transition: border-width 0.3s ease;
 }
 
+// .module-card :deep(.el-card__body) {
+//  transition: all 0.3s ease;
+// }
+
 .module-card :deep(.el-card__body) {
-  transition: all 0.3s ease;
+  padding: 20px; 
 }
 
 .module-node.compact-mode .el-card :deep(.el-card__body) {
@@ -665,15 +669,15 @@ function handleDocumentContextmenu(e) {
   align-items: center;
   justify-content: center;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  transition: opacity 0.3s ease;
-  transition-delay: 0s;
+//  transition: opacity 0.3s ease;
+//  transition-delay: 0s;
 }
 
 .module-name {
   font-size: 14px;
-  transition: font-size 0.3s ease, 
-              font-weight 0.3s ease, 
-              padding 0.3s ease;
+//  transition: font-size 0.3s ease, 
+ //             font-weight 0.3s ease, 
+ //             padding 0.3s ease;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -710,16 +714,16 @@ function handleDocumentContextmenu(e) {
   position: absolute;
   bottom: 8px;
   right: 8px;
-  transition: opacity 0.2s ease;
+ // transition: opacity 0.2s ease;
   opacity: 0;
   pointer-events: none;
-  transition-delay: 0s;
+ // transition-delay: 0s;
 }
 
 .module-node.compact-mode .compact-actions {
   opacity: 1;
   pointer-events: auto;
-  transition-delay: 0.2s;
+ // transition-delay: 0.2s;
 }
 
 .module-node.compact-mode .warning-icon {
@@ -735,7 +739,7 @@ function handleDocumentContextmenu(e) {
   color: var(--el-color-warning);
   font-size: 18px;
   cursor: help;
-  transition: font-size 0.3s ease;
+ // transition: font-size 0.3s ease;
 
   &:hover {
     color: var(--el-color-warning-dark-2);
@@ -744,9 +748,5 @@ function handleDocumentContextmenu(e) {
 
 .module-button {
   margin: 0;
-}
-
-.module-node {
-  will-change: transform;
 }
 </style>

--- a/src/components/ModuleNode.vue
+++ b/src/components/ModuleNode.vue
@@ -11,8 +11,8 @@
     @mousedown.capture="StopDrag"
   >
     <NodeResizer
-      min-width="180"
-      min-height="105"
+      :min-width="NODE_SIZE_LIMITS.WIDTH"
+      :min-height="NODE_SIZE_LIMITS.HEIGHT"
       :is-visible="selected && !isCompactMode"
     />
 
@@ -233,7 +233,7 @@ import { getHandleId, getHandleStyle, portPosition } from '../utils/ports'
 import { sanitiseModuleName } from '../utils/nodes'
 import { notify } from '../utils/notify'
 import { isEditableVariableType, isEmpty } from '../utils/variables'
-import { TOOLTIP_AUTO_CLOSE, ZOOM_BREAKPOINTS } from '../utils/constants'
+import { TOOLTIP_AUTO_CLOSE, ZOOM_BREAKPOINTS, NODE_SIZE_LIMITS } from '../utils/constants'
 import '../assets/vueflownode.css'
 
 const { addEdges, edges, viewport, removeEdges, updateNodeData, updateNodeInternals, nodes } = useVueFlow()
@@ -744,5 +744,9 @@ function handleDocumentContextmenu(e) {
 
 .module-button {
   margin: 0;
+}
+
+.module-node {
+  will-change: transform;
 }
 </style>

--- a/src/components/ModuleNode.vue
+++ b/src/components/ModuleNode.vue
@@ -3,11 +3,18 @@
     class="module-node"
     :id="id"
     ref="moduleNode"
-    :class="{ selected: selected }"
+    :class="{ 
+      selected: selected, 
+      'compact-mode': isCompactMode 
+    }"
     @contextmenu.stop.prevent="openContextMenu"
     @mousedown.capture="StopDrag"
   >
-    <NodeResizer min-width="180" min-height="105" :is-visible="selected" />
+    <NodeResizer
+      min-width="180"
+      min-height="105"
+      :is-visible="selected && !isCompactMode"
+    />
 
     <el-card :class="[domainTypeClass, 'module-card']" shadow="hover">
       <div v-if="isMissingParameters" class="status-indicator">
@@ -18,14 +25,27 @@
         </el-tooltip>
       </div>
 
-      <div class="module-name" @dblclick="startEditing">
-        <span v-if="!isEditing">
-          {{ data.name }}
-        </span>
-        <el-input v-else ref="inputRef" v-model="editingName" size="small" @blur="saveEdit" @keyup.enter="saveEdit" />
+      <div 
+        class="module-name"
+        :class="{ 'compact-name': isCompactMode }"
+        @dblclick="startEditing"
+      >
+        <span v-if="!isEditing">{{ data.name }}</span>
+        <el-input
+          v-else
+          ref="inputRef"
+          v-model="editingName"
+          size="small"
+          @blur="saveEdit"
+          @keyup.enter="saveEdit"
+        />
       </div>
+
       <!-- non-editable label showing CellML component and source file (no white box) -->
-      <div v-if="data.label" class="module-label">{{ data.label }}</div>
+      <!-- hide in compact mode -->
+      <div v-if="data.label && !isCompactMode" class="module-label">
+        {{ data.label }}
+      </div>
       <div class="button-group">
         <el-tooltip
           effect="dark"
@@ -182,9 +202,10 @@ import { getHandleId, getHandleStyle, portPosition } from '../utils/ports'
 import { sanitiseModuleName } from '../utils/nodes'
 import { notify } from '../utils/notify'
 import { isEditableVariableType, isEmpty } from '../utils/variables'
+import { ZOOM_BREAKPOINTS } from '../utils/constants'
 import '../assets/vueflownode.css'
 
-const { addEdges, edges, removeEdges, updateNodeData, updateNodeInternals, nodes } = useVueFlow()
+const { addEdges, edges, viewport, removeEdges, updateNodeData, updateNodeInternals, nodes } = useVueFlow()
 const historyStore = useFlowHistoryStore()
 const builderStore = useBuilderStore()
 
@@ -211,6 +232,16 @@ const emit = defineEmits([
 ])
 
 const moduleNode = ref(null)
+
+// zoom-based display mode
+const displayMode = computed(() => {
+  const zoom = viewport.value.zoom
+  if (zoom < ZOOM_BREAKPOINTS.COMPACT) return 'compact'
+  if (zoom < ZOOM_BREAKPOINTS.NORMAL) return 'simplified'
+  return 'normal'
+})
+
+const isCompactMode = computed(() => displayMode.value === 'compact')
 
 async function openEditDialog() {
   emit('open-edit-dialog', {
@@ -355,6 +386,12 @@ const inputRef = ref(null) // This is a template ref for the input
 
 // This function is triggered by the double-click
 async function startEditing(event) {
+
+  // Don't allow module name editing in compact mode
+  if (isCompactMode.value) {
+    return
+  }
+
   // Don't allow click-through to the flow pane
   event.stopPropagation()
 

--- a/src/components/ModuleNode.vue
+++ b/src/components/ModuleNode.vue
@@ -41,14 +41,13 @@
         />
       </div>
 
-      <!-- non-editable label showing CellML component and source file (no white box) -->
-      <!-- hide in compact mode -->
-      <div v-if="data.label && !isCompactMode" class="module-label">
-        {{ data.label }}
+      <div class="module-label-container">
+        <div v-if="data.label" class="module-label">
+          {{ data.label }}
+        </div>
       </div>
 
-      <!-- Buttons - dropdown in compact, full in normal -->
-      <div v-if="!isCompactMode" class="button-group">
+      <div class="button-group full-mode-group">
         <el-tooltip
           effect="dark"
           content="Set key (colour)"
@@ -56,7 +55,11 @@
           :show-after="300"
           :auto-close="TOOLTIP_AUTO_CLOSE"
         >
-          <el-dropdown trigger="click" @command="handleSetDomainType" @visible-change="(val) => isDropdownOpen = val">
+          <el-dropdown
+            trigger="click"
+            @command="handleSetDomainType"
+            @visible-change="(val) => isDropdownOpen = val"
+          >
             <el-button size="small" circle class="module-button">
               <el-icon><Key /></el-icon>
             </el-button>
@@ -73,19 +76,17 @@
         </el-tooltip>
 
         <el-tooltip
-            class="box-item"
-            effect="dark"
-            content="Add port node"
-            placement="bottom"
-            :show-after="300"
-            :auto-close="TOOLTIP_AUTO_CLOSE"
+          class="box-item"
+          effect="dark"
+          content="Add port node"
+          placement="bottom"
+          :show-after="300"
+          :auto-close="TOOLTIP_AUTO_CLOSE"
         >
           <el-dropdown trigger="click" @command="addPort({ side: $event })">
-          
             <el-button size="small" circle class="module-button">
               <el-icon><Place /></el-icon>
             </el-button>
-          
             <template #dropdown>
               <el-dropdown-menu>
                 <el-dropdown-item command="left">Left</el-dropdown-item>
@@ -96,31 +97,27 @@
             </template>
           </el-dropdown>
         </el-tooltip>
+
         <el-tooltip
-            class="box-item"
-            effect="dark"
-            content="Edit port labels"
-            placement="bottom"
-            :show-after="300"
-            :auto-close="TOOLTIP_AUTO_CLOSE"
+          class="box-item"
+          effect="dark"
+          content="Edit port labels"
+          placement="bottom"
+          :show-after="300"
+          :auto-close="TOOLTIP_AUTO_CLOSE"
         >
-          <el-button
-            size="small"
-            circle
-            @click="openEditDialog"
-            class="module-button"
-          >
+          <el-button size="small" circle @click="openEditDialog" class="module-button">
             <el-icon><Edit /></el-icon>
           </el-button>
         </el-tooltip>
 
         <el-tooltip
-            class="box-item"
-            effect="dark"
-            content="Edit parameters"
-            placement="bottom"
-            :show-after="300"
-            :auto-close="TOOLTIP_AUTO_CLOSE"
+          class="box-item"
+          effect="dark"
+          content="Edit parameters"
+          placement="bottom"
+          :show-after="300"
+          :auto-close="TOOLTIP_AUTO_CLOSE"
         >
           <el-button size="small" circle @click="openEditParameterDialog" class="module-button">
             <el-icon><Operation /></el-icon>
@@ -128,21 +125,14 @@
         </el-tooltip>
 
         <el-tooltip
-            class="box-item"
-            effect="dark"
-            content="Edit CellML Text"
-            placement="bottom"
-            :show-after="300"
-            :auto-close="TOOLTIP_AUTO_CLOSE"
+          class="box-item"
+          effect="dark"
+          content="Edit CellML Text"
+          placement="bottom"
+          :show-after="300"
+          :auto-close="TOOLTIP_AUTO_CLOSE"
         >
-          <el-button
-            size="small"
-            circle
-            @click="openCellMLEditDialog"
-            class="module-button"
-            :show-after="300"
-            :auto-close="TOOLTIP_AUTO_CLOSE"
-          >
+          <el-button size="small" circle @click="openCellMLEditDialog" class="module-button">
             <el-icon><CellMLIcon /></el-icon>
           </el-button>
         </el-tooltip>
@@ -162,7 +152,12 @@
                 :show-after="300"
                 :auto-close="TOOLTIP_AUTO_CLOSE"
               >
-                <el-dropdown trigger="click" teleport="false" @command="handleSetDomainType" @visible-change="(val) => isDropdownOpen = val">
+                <el-dropdown
+                  trigger="click"
+                  teleport="false"
+                  @command="handleSetDomainType"
+                  @visible-change="(val) => isDropdownOpen = val"
+                >
                   <el-button size="default" circle class="module-button">
                     <el-icon><Key /></el-icon>
                   </el-button>
@@ -179,18 +174,16 @@
               </el-tooltip>
 
               <el-tooltip
-                  effect="dark"
-                  content="Add port node"
-                  placement="bottom"
-                  :show-after="300"
-                  :auto-close="TOOLTIP_AUTO_CLOSE"
+                effect="dark"
+                content="Add port node"
+                placement="bottom"
+                :show-after="300"
+                :auto-close="TOOLTIP_AUTO_CLOSE"
               >
                 <el-dropdown trigger="click" teleport="false" @command="addPort({ side: $event })">
-                
                   <el-button size="default" circle class="module-button">
                     <el-icon><Place /></el-icon>
                   </el-button>
-                
                   <template #dropdown>
                     <el-dropdown-menu>
                       <el-dropdown-item command="left">Left</el-dropdown-item>
@@ -201,29 +194,25 @@
                   </template>
                 </el-dropdown>
               </el-tooltip>
+
               <el-tooltip
-                  effect="dark"
-                  content="Edit port labels"
-                  placement="bottom"
-                  :show-after="300"
-                  :auto-close="TOOLTIP_AUTO_CLOSE"
+                effect="dark"
+                content="Edit port labels"
+                placement="bottom"
+                :show-after="300"
+                :auto-close="TOOLTIP_AUTO_CLOSE"
               >
-                <el-button
-                  size="default"
-                  circle
-                  @click="openEditDialog"
-                  class="module-button"
-                >
+                <el-button size="default" circle @click="openEditDialog" class="module-button">
                   <el-icon><Edit /></el-icon>
                 </el-button>
               </el-tooltip>
 
               <el-tooltip
-                  effect="dark"
-                  content="Edit parameters"
-                  placement="bottom"
-                  :show-after="300"
-                  :auto-close="TOOLTIP_AUTO_CLOSE"
+                effect="dark"
+                content="Edit parameters"
+                placement="bottom"
+                :show-after="300"
+                :auto-close="TOOLTIP_AUTO_CLOSE"
               >
                 <el-button size="default" circle @click="openEditParameterDialog" class="module-button">
                   <el-icon><Operation /></el-icon>
@@ -231,20 +220,13 @@
               </el-tooltip>
 
               <el-tooltip
-                  effect="dark"
-                  content="Edit CellML Text"
-                  placement="bottom"
-                  :show-after="300"
-                  :auto-close="TOOLTIP_AUTO_CLOSE"
+                effect="dark"
+                content="Edit CellML Text"
+                placement="bottom"
+                :show-after="300"
+                :auto-close="TOOLTIP_AUTO_CLOSE"
               >
-                <el-button
-                  size="default"
-                  circle
-                  @click="openCellMLEditDialog"
-                  class="module-button"
-                  :show-after="300"
-                  :auto-close="TOOLTIP_AUTO_CLOSE"
-                >
+                <el-button size="default" circle @click="openCellMLEditDialog" class="module-button">
                   <el-icon><CellMLIcon /></el-icon>
                 </el-button>
               </el-tooltip>
@@ -252,11 +234,16 @@
           </template>
         </el-dropdown>
       </div>
-
     </el-card>
 
     <template v-for="port in data.ports" :key="port.uid" class="port">
-      <el-tooltip class="box-item" effect="dark" :content="port.name" placement="bottom" :show-after="1000">
+      <el-tooltip
+        class="box-item"
+        effect="dark"
+        :content="port.name"
+        placement="bottom"
+        :show-after="1000"
+      >
         <Handle
           :id="getHandleId(port)"
           :ref="'handle_' + port.side + '_' + port.uid"
@@ -277,7 +264,7 @@
         </template>
       </el-tooltip>
     </template>
-    <!-- context menu -->
+    
     <teleport to="body">
       <div
         v-if="contextMenuVisible"
@@ -295,7 +282,7 @@
 </template>
 
 <script setup>
-import { computed, nextTick, onMounted, onBeforeUnmount, ref } from 'vue'
+import { computed, nextTick, onMounted, onBeforeUnmount, ref, inject } from 'vue'
 import { Handle, useVueFlow } from '@vue-flow/core'
 import { NodeResizer } from '@vue-flow/node-resizer'
 import { Delete, Edit, Key, Place, MoreFilled, WarningFilled, Operation } from '@element-plus/icons-vue'
@@ -306,26 +293,17 @@ import { getHandleId, getHandleStyle, portPosition } from '../utils/ports'
 import { sanitiseModuleName } from '../utils/nodes'
 import { notify } from '../utils/notify'
 import { isEditableVariableType, isEmpty } from '../utils/variables'
-import { TOOLTIP_AUTO_CLOSE, ZOOM_BREAKPOINTS, NODE_SIZE_LIMITS } from '../utils/constants'
+import { TOOLTIP_AUTO_CLOSE, NODE_SIZE_LIMITS } from '../utils/constants'
 import '../assets/vueflownode.css'
 
-const { addEdges, edges, viewport, removeEdges, updateNodeData, updateNodeInternals, nodes } = useVueFlow()
+const { addEdges, edges, removeEdges, updateNodeData, updateNodeInternals, nodes } = useVueFlow()
 const historyStore = useFlowHistoryStore()
 const builderStore = useBuilderStore()
 
 const props = defineProps({
-  data: {
-    type: Object,
-    required: true,
-  },
-  id: {
-    type: String,
-    required: true,
-  },
-  selected: {
-    type: Boolean,
-    default: false,
-  },
+  data: { type: Object, required: true },
+  id: { type: String, required: true },
+  selected: { type: Boolean, default: false },
 })
 
 const emit = defineEmits([
@@ -335,26 +313,19 @@ const emit = defineEmits([
   'open-parameter-editor-dialog',
 ])
 
-const isInViewport = ref(false)
-const moduleNode = ref(null)
+const isCompactMode = inject('isCompactMode', ref(false))
 
-// zoom-based display mode
-const isCompactMode = computed(() => {
-  if (!isInViewport.value) return false
-  const zoom = viewport.value.zoom
-  return (zoom < ZOOM_BREAKPOINTS.COMPACT) 
-})
+const moduleNode = ref(null)
+const isDropdownOpen = ref(false)
 
 const displayName = computed(() => {
   if (!props.data.name) return ''
-  
-  // In compact mode, insert zero-width space after underscores to allow breaks
   if (isCompactMode.value) {
     return props.data.name.replace(/_/g, '_\u200B')
   }
-  
   return props.data.name
 })
+
 
 async function openEditDialog() {
   emit('open-edit-dialog', {
@@ -385,26 +356,6 @@ function openEditParameterDialog() {
   })
 }
 
-function handleCompactAction(command) {
-  switch(command) {
-    case 'setDomainType':
-      // Show domain type submenu or modal
-      break
-    case 'addPort':
-      // Show port direction submenu or modal
-      break
-    case 'editPorts':
-      openEditDialog()
-      break
-    case 'editParameters':
-      openEditParameterDialog()
-      break
-    case 'editCellML':
-      openCellMLEditDialog()
-      break
-  }
-}
-
 const domainTypeClass = computed(() => {
   return props.data.domainType ? `domain-type-${props.data.domainType}` : 'domain-type-default'
 })
@@ -425,7 +376,6 @@ const isMissingParameters = computed(() => {
       }
     }
   }
-
   return false
 })
 
@@ -436,28 +386,24 @@ function handleSetDomainType(typeCommand) {
 
 const applyPorts = async (portsToSet) => {
   updateNodeData(props.id, { ports: portsToSet })
-
-  // Changing ports adds/removes handles, so we MUST refresh internals
   await nextTick()
   updateNodeInternals(props.id)
 }
 
 async function removePort(portIdToRemove) {
   const oldPorts = JSON.parse(JSON.stringify(props.data.ports))
-
   const port = oldPorts.find((p) => p.uid === portIdToRemove)
   if (!port) return
 
   const handleId = getHandleId(port)
 
   // Find all edges connected to this specific port handle.
-  // We need to snapshot these edge objects so we can restore them later
   const connectedEdges = edges.value.filter(
     (edge) =>
       (edge.source === props.id && edge.sourceHandle === handleId) ||
       (edge.target === props.id && edge.targetHandle === handleId)
   )
-
+  // Snapshot edge objects for later restoration.
   const edgesSnapshot = connectedEdges.map((edge) => JSON.parse(JSON.stringify(edge)))
 
   // Define New Ports (for Redo)
@@ -489,52 +435,25 @@ async function removePort(portIdToRemove) {
 
 const addPort = async (portToAdd) => {
   const oldPorts = [...props.data.ports]
-  // create stable node id
-  const newPort = {
-    ...portToAdd,
-    uid: crypto.randomUUID(),
-  }
-
-  // Create a new array with the old ports + the new one
+  const newPort = { ...portToAdd, uid: crypto.randomUUID() }
   const newPorts = [...props.data.ports, newPort]
-
-  // Tell Vue Flow to update this node's data
-  // This will cause the component to re-render
   await applyPorts(newPorts)
-
   historyStore.addCommand({
     type: 'add-port',
-    undo: async () => {
-      applyPorts(oldPorts)
-    },
-    redo: async () => {
-      applyPorts(newPorts)
-    },
+    undo: async () => applyPorts(oldPorts),
+    redo: async () => applyPorts(newPorts),
   })
 }
 
 const isEditing = ref(false)
 const editingName = ref('')
-const inputRef = ref(null) // This is a template ref for the input
+const inputRef = ref(null)
 
-// This function is triggered by the double-click
 async function startEditing(event) {
-
-  // Don't allow module name editing in compact mode
-  // if (isCompactMode.value) {
-  //   return
-  // }
-
-  // Don't allow click-through to the flow pane
   event.stopPropagation()
-
   isEditing.value = true
   editingName.value = props.data.name
-
-  // Wait for Vue to re-render and show the input
   await nextTick()
-
-  // Focus the input
   inputRef.value?.focus()
 }
 
@@ -544,7 +463,6 @@ function StopDrag(event) {
   }
 }
 
-// This is triggered by pressing Enter or clicking away
 function saveEdit() {
   if (!editingName.value || editingName.value.trim() === '') {
     isEditing.value = false
@@ -565,7 +483,6 @@ function saveEdit() {
     return
   }
 
-  // Update the node's data in the store
   updateNodeData(props.id, { name: sanitisedName })
   isEditing.value = false
   setTimeout(() => {
@@ -577,7 +494,7 @@ function saveEdit() {
       props.data.configIndex
     )
     updateNodeData(props.id, { variables: props.data.variables })
-  }, 100) // Delay to ensure the DOM has updated
+  }, 100)
 }
 
 const contextMenuVisible = ref(false)
@@ -609,31 +526,15 @@ function closeContextMenu() {
   removeMenuOpenListeners()
 }
 
-let observer
-
 onMounted(() => {
   document.addEventListener('module-context-open', handleExternalContextOpen)
   document.addEventListener('contextmenu', handleDocumentContextmenu)
-  observer = new IntersectionObserver(
-    ([entry]) => {
-      isInViewport.value = entry.isIntersecting
-    },
-    {
-      root: document.querySelector('.vue-flow__viewport'),
-      threshold: 0.2, // 20% visible before marked 'visible'
-    }
-  )
-
-  if (moduleNode.value) {
-    observer?.observe(moduleNode.value)
-  }
 })
 
 onBeforeUnmount(() => {
   document.removeEventListener('module-context-open', handleExternalContextOpen)
   document.removeEventListener('contextmenu', handleDocumentContextmenu)
   removeMenuOpenListeners()
-  observer?.disconnect()
 })
 
 async function openContextMenu(event) {
@@ -654,10 +555,7 @@ async function openContextMenu(event) {
   contextMenuX.value = x
   contextMenuY.value = y
   contextMenuVisible.value = true
-
   await nextTick()
-
-  // close when clicking elsewhere and pointer down/drag start
   document.addEventListener('click', closeContextMenu)
   document.addEventListener('dragstart', closeContextMenu)
   document.addEventListener('pointerdown', onDocumentPointerDown, true)
@@ -674,7 +572,6 @@ async function openReplacementDialog() {
   closeContextMenu()
 }
 
-// Close when another module opens a context menu or when right-click happens outside this node
 function handleExternalContextOpen(e) {
   const openId = e?.detail?.nodeId ?? null
   if (openId !== props.id) {
@@ -701,20 +598,8 @@ function handleDocumentContextmenu(e) {
   height: 100%;
   box-sizing: border-box;
   border-radius: 10px;
-}
-
-.button-group {
- // transition: opacity 0.3s ease, visibility 0.3s ease;
-  opacity: 1;
-  visibility: visible;
- // transition-delay: 0.2s; 
-}
-
-.module-node.compact-mode .button-group {
-  opacity: 0;
-  visibility: hidden;
-  pointer-events: none;
-//  transition-delay: 0s; 
+  contain: layout style;
+  will-change: transform; 
 }
 
 .module-node > .el-card,
@@ -728,23 +613,58 @@ function handleDocumentContextmenu(e) {
   border: 3px solid rgba(0,0,0,0.04);
   display: flex;
   flex-direction: column;
-//  transition: border-width 0.3s ease;
 }
-
-// .module-card :deep(.el-card__body) {
-//  transition: all 0.3s ease;
-// }
 
 .module-card :deep(.el-card__body) {
   padding: 20px; 
-}
-
-.module-node.compact-mode .el-card :deep(.el-card__body) {
+  transition: padding 0.2s ease;
+  flex: 1;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  flex: 1;
+}
+
+/* COMPACT MODE STYLES */
+.module-node.compact-mode .el-card :deep(.el-card__body) {
   padding: 8px;
+  justify-content: center;
+}
+
+.module-node.compact-mode .button-group,
+.module-node.compact-mode .module-label-container {
+  display: none !important;
+}
+
+.module-node.compact-mode .compact-actions {
+  opacity: 1;
+  pointer-events: auto;
+  display: block;
+}
+
+.module-node.compact-mode .warning-icon {
+  font-size: 24px;
+}
+
+.module-node.compact-mode .status-indicator {
+  top: 8px;
+  right: 8px;
+}
+
+/* NORMAL MODE STYLES */
+.button-group {
+  opacity: 1;
+  visibility: visible;
+  display: flex;
+  margin-top: auto;
+  gap: 4px;
+}
+
+.compact-actions {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  opacity: 0;
+  pointer-events: none;
+  display: none;
 }
 
 .status-indicator {
@@ -760,18 +680,14 @@ function handleDocumentContextmenu(e) {
   align-items: center;
   justify-content: center;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-//  transition: opacity 0.3s ease;
-//  transition-delay: 0s;
 }
 
 .module-name {
   font-size: 14px;
-//  transition: font-size 0.3s ease, 
- //             font-weight 0.3s ease, 
- //             padding 0.3s ease;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  transition: font-size 0.2s ease; 
 
   &.compact-name {
     font-size: 18px;
@@ -801,37 +717,10 @@ function handleDocumentContextmenu(e) {
   }
 }
 
-.compact-actions {
-  position: absolute;
-  bottom: 8px;
-  right: 8px;
- // transition: opacity 0.2s ease;
-  opacity: 0;
-  pointer-events: none;
- // transition-delay: 0s;
-}
-
-.module-node.compact-mode .compact-actions {
-  opacity: 1;
-  pointer-events: auto;
- // transition-delay: 0.2s;
-}
-
-.module-node.compact-mode .warning-icon {
-  font-size: 24px;
-}
-
-.module-node.compact-mode .status-indicator {
-  top: 8px;
-  right: 8px;
-}
-
 .warning-icon {
   color: var(--el-color-warning);
   font-size: 18px;
   cursor: help;
- // transition: font-size 0.3s ease;
-
   &:hover {
     color: var(--el-color-warning-dark-2);
   }
@@ -846,5 +735,4 @@ function handleDocumentContextmenu(e) {
   gap: 8px;
   display: flex;
 }
-
 </style>

--- a/src/components/ModuleNode.vue
+++ b/src/components/ModuleNode.vue
@@ -149,33 +149,106 @@
       </div>
 
       <div class="compact-actions">
-        <el-dropdown trigger="click" @command="handleCompactAction">
-          <el-button size="small" circle class="compact-menu-button">
+        <el-dropdown trigger="click" effect="dark" popper-class="compact-actions-popper">
+          <el-button size="small" circle class="menu-button">
             <el-icon><MoreFilled /></el-icon>
           </el-button>
           <template #dropdown>
-            <el-dropdown-menu>
-              <el-dropdown-item command="setDomainType">
-                <el-icon><Key /></el-icon>
-                Set Key (Colour)
-              </el-dropdown-item>
-              <el-dropdown-item command="addPort">
-                <el-icon><Place /></el-icon>
-                Add Port
-              </el-dropdown-item>
-              <el-dropdown-item command="editPorts">
-                <el-icon><Edit /></el-icon>
-                Edit Port Labels
-              </el-dropdown-item>
-              <el-dropdown-item command="editParameters">
-                <el-icon><Operation /></el-icon>
-                Edit Parameters
-              </el-dropdown-item>
-              <el-dropdown-item command="editCellML">
-                <el-icon><CellMLIcon /></el-icon>
-                Edit CellML Text
-              </el-dropdown-item>
-            </el-dropdown-menu>
+            <div class="compact-actions-wrapper">
+              <el-tooltip
+                effect="dark"
+                content="Set key (colour)"
+                placement="bottom"
+                :show-after="300"
+                :auto-close="TOOLTIP_AUTO_CLOSE"
+              >
+                <el-dropdown trigger="click" teleport="false" @command="handleSetDomainType" @visible-change="(val) => isDropdownOpen = val">
+                  <el-button size="default" circle class="module-button">
+                    <el-icon><Key /></el-icon>
+                  </el-button>
+                  <template #dropdown>
+                    <el-dropdown-menu>
+                      <el-dropdown-item command="membrane">Membrane</el-dropdown-item>
+                      <el-dropdown-item command="process">Process</el-dropdown-item>
+                      <el-dropdown-item command="compartment">Compartment</el-dropdown-item>
+                      <el-dropdown-item command="protein">Protein</el-dropdown-item>
+                      <el-dropdown-item command="undefined" divided>Reset to Default</el-dropdown-item>
+                    </el-dropdown-menu>
+                  </template>
+                </el-dropdown>
+              </el-tooltip>
+
+              <el-tooltip
+                  effect="dark"
+                  content="Add port node"
+                  placement="bottom"
+                  :show-after="300"
+                  :auto-close="TOOLTIP_AUTO_CLOSE"
+              >
+                <el-dropdown trigger="click" teleport="false" @command="addPort({ side: $event })">
+                
+                  <el-button size="default" circle class="module-button">
+                    <el-icon><Place /></el-icon>
+                  </el-button>
+                
+                  <template #dropdown>
+                    <el-dropdown-menu>
+                      <el-dropdown-item command="left">Left</el-dropdown-item>
+                      <el-dropdown-item command="right">Right</el-dropdown-item>
+                      <el-dropdown-item command="top">Top</el-dropdown-item>
+                      <el-dropdown-item command="bottom">Bottom</el-dropdown-item>
+                    </el-dropdown-menu>
+                  </template>
+                </el-dropdown>
+              </el-tooltip>
+              <el-tooltip
+                  effect="dark"
+                  content="Edit port labels"
+                  placement="bottom"
+                  :show-after="300"
+                  :auto-close="TOOLTIP_AUTO_CLOSE"
+              >
+                <el-button
+                  size="default"
+                  circle
+                  @click="openEditDialog"
+                  class="module-button"
+                >
+                  <el-icon><Edit /></el-icon>
+                </el-button>
+              </el-tooltip>
+
+              <el-tooltip
+                  effect="dark"
+                  content="Edit parameters"
+                  placement="bottom"
+                  :show-after="300"
+                  :auto-close="TOOLTIP_AUTO_CLOSE"
+              >
+                <el-button size="default" circle @click="openEditParameterDialog" class="module-button">
+                  <el-icon><Operation /></el-icon>
+                </el-button>
+              </el-tooltip>
+
+              <el-tooltip
+                  effect="dark"
+                  content="Edit CellML Text"
+                  placement="bottom"
+                  :show-after="300"
+                  :auto-close="TOOLTIP_AUTO_CLOSE"
+              >
+                <el-button
+                  size="default"
+                  circle
+                  @click="openCellMLEditDialog"
+                  class="module-button"
+                  :show-after="300"
+                  :auto-close="TOOLTIP_AUTO_CLOSE"
+                >
+                  <el-icon><CellMLIcon /></el-icon>
+                </el-button>
+              </el-tooltip>
+            </div>
           </template>
         </el-dropdown>
       </div>
@@ -767,4 +840,11 @@ function handleDocumentContextmenu(e) {
 .module-button {
   margin: 0;
 }
+
+.compact-actions-wrapper {
+  padding: 10px 12px;
+  gap: 8px;
+  display: flex;
+}
+
 </style>

--- a/src/components/ModuleNode.vue
+++ b/src/components/ModuleNode.vue
@@ -30,12 +30,12 @@
         :class="{ 'compact-name': isCompactMode }"
         @dblclick="startEditing"
       >
-        <span v-if="!isEditing">{{ data.name }}</span>
+        <span v-if="!isEditing">{{ displayName }}</span>
         <el-input
           v-else
           ref="inputRef"
           v-model="editingName"
-          size="small"
+          :size="isCompactMode ? 'default' : 'small'"
           @blur="saveEdit"
           @keyup.enter="saveEdit"
         />
@@ -46,13 +46,15 @@
       <div v-if="data.label && !isCompactMode" class="module-label">
         {{ data.label }}
       </div>
-      <div class="button-group">
+
+      <!-- Buttons - dropdown in compact, full in normal -->
+      <div v-if="!isCompactMode" class="button-group">
         <el-tooltip
           effect="dark"
           content="Set key (colour)"
           placement="bottom"
           :show-after="300"
-          :auto-close="1200"
+          :auto-close="TOOLTIP_AUTO_CLOSE"
         >
           <el-dropdown trigger="click" @command="handleSetDomainType" @visible-change="(val) => isDropdownOpen = val">
             <el-button size="small" circle class="module-button">
@@ -62,13 +64,9 @@
               <el-dropdown-menu>
                 <el-dropdown-item command="membrane">Membrane</el-dropdown-item>
                 <el-dropdown-item command="process">Process</el-dropdown-item>
-                <el-dropdown-item command="compartment"
-                  >Compartment</el-dropdown-item
-                >
+                <el-dropdown-item command="compartment">Compartment</el-dropdown-item>
                 <el-dropdown-item command="protein">Protein</el-dropdown-item>
-                <el-dropdown-item command="undefined" divided
-                  >Reset to Default</el-dropdown-item
-                >
+                <el-dropdown-item command="undefined" divided>Reset to Default</el-dropdown-item>
               </el-dropdown-menu>
             </template>
           </el-dropdown>
@@ -80,7 +78,7 @@
             content="Add port node"
             placement="bottom"
             :show-after="300"
-            :auto-close="1200"
+            :auto-close="TOOLTIP_AUTO_CLOSE"
         >
           <el-dropdown trigger="click" @command="addPort({ side: $event })">
           
@@ -104,7 +102,7 @@
             content="Edit port labels"
             placement="bottom"
             :show-after="300"
-            :auto-close="1200"
+            :auto-close="TOOLTIP_AUTO_CLOSE"
         >
           <el-button
             size="small"
@@ -122,7 +120,7 @@
             content="Edit parameters"
             placement="bottom"
             :show-after="300"
-            :auto-close="1200"
+            :auto-close="TOOLTIP_AUTO_CLOSE"
         >
           <el-button size="small" circle @click="openEditParameterDialog" class="module-button">
             <el-icon><Operation /></el-icon>
@@ -135,7 +133,7 @@
             content="Edit CellML Text"
             placement="bottom"
             :show-after="300"
-            :auto-close="1200"
+            :auto-close="TOOLTIP_AUTO_CLOSE"
         >
           <el-button
             size="small"
@@ -143,12 +141,45 @@
             @click="openCellMLEditDialog"
             class="module-button"
             :show-after="300"
-            :auto-close="1200"
+            :auto-close="TOOLTIP_AUTO_CLOSE"
           >
             <el-icon><CellMLIcon /></el-icon>
           </el-button>
         </el-tooltip>
       </div>
+
+      <div class="compact-actions">
+        <el-dropdown trigger="click" @command="handleCompactAction">
+          <el-button size="small" circle class="compact-menu-button">
+            <el-icon><MoreFilled /></el-icon>
+          </el-button>
+          <template #dropdown>
+            <el-dropdown-menu>
+              <el-dropdown-item command="setDomainType">
+                <el-icon><Key /></el-icon>
+                Set Key (Colour)
+              </el-dropdown-item>
+              <el-dropdown-item command="addPort">
+                <el-icon><Place /></el-icon>
+                Add Port
+              </el-dropdown-item>
+              <el-dropdown-item command="editPorts">
+                <el-icon><Edit /></el-icon>
+                Edit Port Labels
+              </el-dropdown-item>
+              <el-dropdown-item command="editParameters">
+                <el-icon><Operation /></el-icon>
+                Edit Parameters
+              </el-dropdown-item>
+              <el-dropdown-item command="editCellML">
+                <el-icon><CellMLIcon /></el-icon>
+                Edit CellML Text
+              </el-dropdown-item>
+            </el-dropdown-menu>
+          </template>
+        </el-dropdown>
+      </div>
+
     </el-card>
 
     <template v-for="port in data.ports" :key="port.uid" class="port">
@@ -194,7 +225,7 @@
 import { computed, nextTick, onMounted, onBeforeUnmount, ref } from 'vue'
 import { Handle, useVueFlow } from '@vue-flow/core'
 import { NodeResizer } from '@vue-flow/node-resizer'
-import { Delete, Edit, Key, Place, WarningFilled, Operation } from '@element-plus/icons-vue'
+import { Delete, Edit, Key, Place, MoreFilled, WarningFilled, Operation } from '@element-plus/icons-vue'
 import CellMLIcon from './icons/CellMLIcon.vue'
 import { useBuilderStore } from '../stores/builderStore'
 import { useFlowHistoryStore } from '../stores/historyStore'
@@ -202,7 +233,7 @@ import { getHandleId, getHandleStyle, portPosition } from '../utils/ports'
 import { sanitiseModuleName } from '../utils/nodes'
 import { notify } from '../utils/notify'
 import { isEditableVariableType, isEmpty } from '../utils/variables'
-import { ZOOM_BREAKPOINTS } from '../utils/constants'
+import { TOOLTIP_AUTO_CLOSE, ZOOM_BREAKPOINTS } from '../utils/constants'
 import '../assets/vueflownode.css'
 
 const { addEdges, edges, viewport, removeEdges, updateNodeData, updateNodeInternals, nodes } = useVueFlow()
@@ -234,14 +265,21 @@ const emit = defineEmits([
 const moduleNode = ref(null)
 
 // zoom-based display mode
-const displayMode = computed(() => {
+const isCompactMode = computed(() => {
   const zoom = viewport.value.zoom
-  if (zoom < ZOOM_BREAKPOINTS.COMPACT) return 'compact'
-  if (zoom < ZOOM_BREAKPOINTS.NORMAL) return 'simplified'
-  return 'normal'
+  return (zoom < ZOOM_BREAKPOINTS.COMPACT) 
 })
 
-const isCompactMode = computed(() => displayMode.value === 'compact')
+const displayName = computed(() => {
+  if (!props.data.name) return ''
+  
+  // In compact mode, insert zero-width space after underscores to allow breaks
+  if (isCompactMode.value) {
+    return props.data.name.replace(/_/g, '_\u200B')
+  }
+  
+  return props.data.name
+})
 
 async function openEditDialog() {
   emit('open-edit-dialog', {
@@ -270,6 +308,26 @@ function openEditParameterDialog() {
     componentName: props.data.componentName,
     sourceFile: props.data.sourceFile,
   })
+}
+
+function handleCompactAction(command) {
+  switch(command) {
+    case 'setDomainType':
+      // Show domain type submenu or modal
+      break
+    case 'addPort':
+      // Show port direction submenu or modal
+      break
+    case 'editPorts':
+      openEditDialog()
+      break
+    case 'editParameters':
+      openEditParameterDialog()
+      break
+    case 'editCellML':
+      openCellMLEditDialog()
+      break
+  }
 }
 
 const domainTypeClass = computed(() => {
@@ -388,9 +446,9 @@ const inputRef = ref(null) // This is a template ref for the input
 async function startEditing(event) {
 
   // Don't allow module name editing in compact mode
-  if (isCompactMode.value) {
-    return
-  }
+  // if (isCompactMode.value) {
+  //   return
+  // }
 
   // Don't allow click-through to the flow pane
   event.stopPropagation()
@@ -554,6 +612,20 @@ function handleDocumentContextmenu(e) {
   border-radius: 10px;
 }
 
+.button-group {
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+  opacity: 1;
+  visibility: visible;
+  transition-delay: 0.2s; 
+}
+
+.module-node.compact-mode .button-group {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition-delay: 0s; 
+}
+
 .module-node > .el-card,
 .module-card {
   width: 100%;
@@ -563,6 +635,21 @@ function handleDocumentContextmenu(e) {
   box-sizing: border-box;
   position: relative;
   border: 3px solid rgba(0,0,0,0.04);
+  display: flex;
+  flex-direction: column;
+  transition: border-width 0.3s ease;
+}
+
+.module-card :deep(.el-card__body) {
+  transition: all 0.3s ease;
+}
+
+.module-node.compact-mode .el-card :deep(.el-card__body) {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  flex: 1;
+  padding: 8px;
 }
 
 .status-indicator {
@@ -570,10 +657,6 @@ function handleDocumentContextmenu(e) {
   top: 0px;
   right: 0px;
   z-index: 10;
-  /* Ensure it sits above other card content */
-
-  /* Optional: Add a white background circle so the icon pops 
-     if it overlaps a border or busy background */
   background-color: white;
   border-radius: 50%;
   width: 20px;
@@ -582,13 +665,77 @@ function handleDocumentContextmenu(e) {
   align-items: center;
   justify-content: center;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: opacity 0.3s ease;
+  transition-delay: 0s;
+}
+
+.module-name {
+  font-size: 14px;
+  transition: font-size 0.3s ease, 
+              font-weight 0.3s ease, 
+              padding 0.3s ease;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  &.compact-name {
+    font-size: 18px;
+    margin-left: 10px;
+    font-weight: 600;
+    padding: 8px 4px;
+    white-space: normal;
+    word-break: keep-all;
+    overflow-wrap: break-word;
+    line-height: 1.3;
+
+    :deep(.el-input__wrapper) {
+      font-size: 18px;
+      padding: 8px 12px;
+      min-height: 40px;
+    }
+    
+    :deep(.el-input__inner) {
+      font-size: 18px;
+      font-weight: 600;
+      text-align: center;
+      white-space: normal;
+      word-break: keep-all;
+      overflow-wrap: break-word;
+      line-height: 1.3;
+    }
+  }
+}
+
+.compact-actions {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  transition: opacity 0.2s ease;
+  opacity: 0;
+  pointer-events: none;
+  transition-delay: 0s;
+}
+
+.module-node.compact-mode .compact-actions {
+  opacity: 1;
+  pointer-events: auto;
+  transition-delay: 0.2s;
+}
+
+.module-node.compact-mode .warning-icon {
+  font-size: 24px;
+}
+
+.module-node.compact-mode .status-indicator {
+  top: 8px;
+  right: 8px;
 }
 
 .warning-icon {
   color: var(--el-color-warning);
-  /* Standard Element Plus Orange */
   font-size: 18px;
   cursor: help;
+  transition: font-size 0.3s ease;
 
   &:hover {
     color: var(--el-color-warning-dark-2);

--- a/src/components/ModuleNode.vue
+++ b/src/components/ModuleNode.vue
@@ -262,10 +262,12 @@ const emit = defineEmits([
   'open-parameter-editor-dialog',
 ])
 
+const isInViewport = ref(false)
 const moduleNode = ref(null)
 
 // zoom-based display mode
 const isCompactMode = computed(() => {
+  if (!isInViewport.value) return false
   const zoom = viewport.value.zoom
   return (zoom < ZOOM_BREAKPOINTS.COMPACT) 
 })
@@ -534,15 +536,31 @@ function closeContextMenu() {
   removeMenuOpenListeners()
 }
 
+let observer
+
 onMounted(() => {
   document.addEventListener('module-context-open', handleExternalContextOpen)
   document.addEventListener('contextmenu', handleDocumentContextmenu)
+  observer = new IntersectionObserver(
+    ([entry]) => {
+      isInViewport.value = entry.isIntersecting
+    },
+    {
+      root: document.querySelector('.vue-flow__viewport'),
+      threshold: 0.2, // 20% visible before marked 'visible'
+    }
+  )
+
+  if (moduleNode.value) {
+    observer?.observe(moduleNode.value)
+  }
 })
 
 onBeforeUnmount(() => {
   document.removeEventListener('module-context-open', handleExternalContextOpen)
   document.removeEventListener('contextmenu', handleDocumentContextmenu)
   removeMenuOpenListeners()
+  observer?.disconnect()
 })
 
 async function openContextMenu(event) {

--- a/src/services/import/buildWorkflow.js
+++ b/src/services/import/buildWorkflow.js
@@ -1,6 +1,6 @@
 import { buildPorts, buildPortLabels } from './buildPorts'
 import { getHandleId } from '../../utils/ports'
-import { SOURCE_PORT_TYPE, TARGET_PORT_TYPE } from '../../utils/constants'
+import { SOURCE_PORT_TYPE, TARGET_PORT_TYPE, NODE_SIZE_LIMITS } from '../../utils/constants'
 import { extractVariablesFromModule } from '../../utils/cellml'
 
 function buildNodes(builderStore, vessels, progressCallback = null) {
@@ -64,6 +64,8 @@ function buildNodes(builderStore, vessels, progressCallback = null) {
             position: { x: 100, y: 100 },
             style: { opacity: 0 }, // Hidden until layout runs
           }),
+      width: NODE_SIZE_LIMITS.WIDTH,
+      height: NODE_SIZE_LIMITS.HEIGHT,
       data: {
         componentName: module.componentName,
         configIndex: configIndex,

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -18,6 +18,11 @@ export const ZOOM_LIMITS = {
   MIN: 0.4,
 }
 
+export const NODE_SIZE_LIMITS = {
+  HEIGHT: 105,
+  WIDTH: 205,
+}
+
 export const markerEnd = MarkerType.ArrowClosed
 export const edgeLineOptions = {
   type: 'smoothstep',

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -15,7 +15,7 @@ export const ZOOM_BREAKPOINTS = {
 
 export const ZOOM_LIMITS = {
   MAX: 1.5,
-  MIN: 0.4,
+  MIN: 0.1,
 }
 
 export const NODE_SIZE_LIMITS = {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -8,6 +8,18 @@ export const TOOLTIP_AUTO_CLOSE = 1200
 export const RESCALE_ASPECT_RATIO = 3
 export const RESCALE_TARGET_SPACING = 1000
 
+// constants for zoom-based dynamic module node content 
+export const ZOOM_BREAKPOINTS = {
+  COMPACT: 0.6,
+  NORMAL: 0.75,
+  LARGE: 1.0,
+}
+
+export const ZOOM_LIMITS = {
+  MAX: 1.5,
+  MIN: 0.4,
+}
+
 export const markerEnd = MarkerType.ArrowClosed
 export const edgeLineOptions = {
   type: 'smoothstep',

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -10,9 +10,7 @@ export const RESCALE_TARGET_SPACING = 1000
 
 // constants for zoom-based dynamic module node content 
 export const ZOOM_BREAKPOINTS = {
-  COMPACT: 0.6,
-  NORMAL: 0.75,
-  LARGE: 1.0,
+  COMPACT: 0.7,
 }
 
 export const ZOOM_LIMITS = {

--- a/src/views/BuilderView.vue
+++ b/src/views/BuilderView.vue
@@ -211,7 +211,6 @@
             :min-zoom="ZOOM_LIMITS.MIN"
             :default-edge-options="edgeLineOptions"
             :connection-line-options="edgeLineOptions"
-            :nodes="nodes"
             :delete-key-code="['Backspace', 'Delete']"
           >
             <HelperLines :horizontal="helperLineHorizontal" :vertical="helperLineVertical" :alignment="alignment" />
@@ -300,7 +299,8 @@ export default {
 </script>
 
 <script setup>
-import { computed, h, inject, markRaw, nextTick, onMounted, onUnmounted, ref, watch, watchPostEffect } from 'vue'
+import { computed, h, inject, markRaw, nextTick, provide, 
+  onMounted, onUnmounted, ref, watch, watchPostEffect } from 'vue'
 import { useVueFlow, VueFlow } from '@vue-flow/core'
 import {
   DCaret,
@@ -342,7 +342,8 @@ import { getHelperLines } from '../utils/helperLines'
 import { getPurgedUrlForResource, getUrlForResource, loadManifest } from '../utils/resources'
 import { useClearWorkspace } from '../utils/workspace'
 import { relayoutNodes } from '../services/layouts/physics'
-import { generateFlattenedModel, initLibCellML, processModuleData, processUnitsData } from '../utils/cellml'
+import { generateFlattenedModel, initLibCellML, 
+  processModuleData, processUnitsData } from '../utils/cellml'
 import {
   edgeLineOptions,
   CELLML_FILE_TYPES,
@@ -350,6 +351,7 @@ import {
   IMPORT_KEYS,
   EXPORT_KEYS,
   JSON_FILE_TYPES,
+  ZOOM_BREAKPOINTS,
   ZIP_FILE_TYPES,
   ZOOM_LIMITS,
 } from '../utils/constants'
@@ -359,11 +361,6 @@ import { getImportConfig, parseParametersFile } from '../utils/import'
 import { legacyDownload, saveFileHandle, writeFileHandle } from '../utils/save'
 import CellMLEditorDialog from '../components/CellMLEditorDialog.vue'
 import EditParameterDialog from '../components/EditParameterDialog.vue'
-
-// import testModuleBGContent from '../assets/bg_modules.cellml?raw'
-// import testModuleColonContent from '../assets/colon_FTU_modules.cellml?raw'
-// import testModuleNewColonContent from '../assets/colon_FTU_modules_new.cellml?raw'
-// import testParamertersCSV from '../assets/colon_FTU_parameters.csv?raw'
 
 const {
   addEdges,
@@ -422,6 +419,12 @@ const currentEditingNode = ref({
   ports: [],
   name: '',
 })
+
+const isCompactMode = computed(() => {
+  return viewport.value.zoom < ZOOM_BREAKPOINTS.COMPACT
+})
+provide('isCompactMode', isCompactMode)
+
 const importDialogRef = ref(null)
 
 const currentImportMode = ref(null)

--- a/src/views/BuilderView.vue
+++ b/src/views/BuilderView.vue
@@ -207,8 +207,8 @@
             @dragleave="onDragLeave"
             @nodes-change="onNodeChange"
             @edges-change="onEdgeChange"
-            :max-zoom="1.5"
-            :min-zoom="0.1"
+            :max-zoom="ZOOM_LIMITS.MAX"
+            :min-zoom="ZOOM_LIMITS.MIN"
             :default-edge-options="edgeLineOptions"
             :connection-line-options="edgeLineOptions"
             :nodes="nodes"
@@ -351,6 +351,7 @@ import {
   EXPORT_KEYS,
   JSON_FILE_TYPES,
   ZIP_FILE_TYPES,
+  ZOOM_LIMITS,
 } from '../utils/constants'
 import { getId as getNextNodeId, generateUniqueModuleName } from '../utils/nodes'
 import { getId as getNextEdgeId } from '../utils/edges'


### PR DESCRIPTION
Switches the contents of the modules nodes depending on the zoom state. 

Compact mode removes most of the content, making the module name much more visible and moving the buttons to a dropdown triggered by a single button in the module's corner.

I've played around with optimisations to smooth out the transition, and it's OK(ish) on my screen. Would like a few people to try it out before we merge it into production. 

I also changed the zoom limits so the module name remains visible at the minimum zoom. It's nice to see all the modules in theory, but it's not useful if you can't identify what they are.

Resolves #94. 