### PR TITLE
Fix cellml export for constants

### DIFF
--- a/src/utils/cellml.js
+++ b/src/utils/cellml.js
@@ -679,6 +679,16 @@ export function generateFlattenedModel(nodes, edges, builderStore) {
     parameterComponent.setName(MODEL_PARAMETERS)
     model.addComponent(parameterComponent)
 
+    // Count how many nodes use each constant variable name
+    const constantNameRefCount = new Map()
+    for (const node of nodes) {
+      for (const v of (node.data.variables ?? [])) {
+        if (v.type === 'constant' && !isEmpty(v.value)) {
+          constantNameRefCount.set(v.name, (constantNameRefCount.get(v.name) ?? 0) + 1)
+        }
+      }
+    }
+
     // ---------------------------------
     // Process Nodes (Create Components)
     // ---------------------------------
@@ -737,9 +747,10 @@ export function generateFlattenedModel(nodes, edges, builderStore) {
           } else if (nodeVariable.type === 'constant') {
             const v = node.data.variables.find((cv) => cv.name === nodeVariable.name)
             if (!isEmpty(v?.value)) {
+              const isShared = (constantNameRefCount.get(v.name) ?? 0) > 1
               addVariableToParameterComponent(model, variable, parameterComponent, {
                 ...v,
-                name: `${node.data.name}_${v.name}`, 
+                name: isShared ? `${node.data.name}_${v.name}` : v.name,
               })
             }
           }
@@ -830,7 +841,6 @@ export function generateFlattenedModel(nodes, edges, builderStore) {
       }
     }
 
-    // throw new Error('Debugging multi-port-sum connections.')
     // Handle Multi-Port-Sum Connections
     for (const sumData of multiPortSums.values()) {
       const { sourceComp, srcLabel, targets } = sumData
@@ -894,7 +904,6 @@ export function generateFlattenedModel(nodes, edges, builderStore) {
       // FIXME: There is a bug in libCellML v0.6.3 where the analyser cannot handle
       // initialisation of a variable that is computed. Fixed in v0.6.4, but we need 
       // a workaround for now to at least export something usable in the case where this is the only error.
-      // flattenedModel.delete()
       handleLoggerErrors(analyser, `Analyser error count: ${analyser.errorCount()}`, true)
     }
 


### PR DESCRIPTION
Constants were being greedily claimed by the first component that had declared them. Now check for variables (constants) that are used in multiple instances, and rename them if they have multiple uses (instance name_variable name).

Resolves #390.