### PR TITLE
Add editable title to the application header

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,12 @@
         <img src="/phlynxlogo.svg" alt="PhLynx Logo" class="centred-image" />
         <strong>PhLynx v{{ appVersion }}</strong>
       </div>
+      <div class="session-name" @dblclick="startEditing">
+       <strong v-if="!isEditing">
+          {{ sessionName }}
+       </strong> 
+        <el-input v-else ref="inputRef" v-model="editingValue" @blur="saveEdit" @keyup.enter="saveEdit" @keyup.esc="cancelEdit"/>
+      </div>
       <nav>
         <router-link to="/">Workbench</router-link>
         <router-link to="/docs/" :class="{ 'force-active': isDocsActive }">User Guide</router-link>
@@ -26,15 +32,53 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref, nextTick } from 'vue'
 import { useRoute } from 'vue-router'
+import { useBuilderStore } from './stores/builderStore'
 
 const appVersion = __APP_VERSION__ + __BUILD_STATE_MARKER__
 const route = useRoute()
+const builderStore = useBuilderStore()
+
+const sessionName = computed(() => builderStore.lastSaveName)
+
+const editingValue = ref('')
+const isEditing = ref(false)
+const inputRef = ref(null)
 
 const isDocsActive = computed(() => {
   return route.path.startsWith('/docs')
 })
+
+async function startEditing(e) {
+  e.stopPropagation()
+
+  editingValue.value = sessionName.value
+  isEditing.value = true
+
+  await nextTick()
+  inputRef.value?.focus()
+  inputRef.value?.select()
+}
+
+function saveEdit() {
+  const name = editingValue.value.trim()
+
+  if (!name) {
+    cancelEdit()
+    return
+  }
+
+  if (name !== sessionName.value) {
+    builderStore.setLastSaveName(name)
+  }
+
+  isEditing.value = false
+}
+
+function cancelEdit() {
+  isEditing.value = false
+}
 </script>
 
 <style>
@@ -86,5 +130,17 @@ const isDocsActive = computed(() => {
   max-width: 40px;
   height: auto;
   padding-right: 10px;
+}
+
+.session-name {
+  cursor: text;
+}
+
+.session-name:hover {
+  color: #409eff;
+}
+
+.session-name {
+  min-width: 200px;
 }
 </style>


### PR DESCRIPTION
The title at the top is populated using the "last save name" from the builder store. Users can then edit this, and it feeds into any saves they perform (shown below).

<img width="1503" height="554" alt="Screenshot 2026-03-16 at 6 44 25 PM" src="https://github.com/user-attachments/assets/42183ab6-6c93-446b-91de-1f4792c884ee" />

<img width="1507" height="544" alt="Screenshot 2026-03-16 at 6 44 36 PM" src="https://github.com/user-attachments/assets/c2be5d6b-54b9-4a83-9034-52572a0f1407" />

<img width="1509" height="506" alt="Screenshot 2026-03-16 at 6 44 43 PM" src="https://github.com/user-attachments/assets/5373febf-4344-4fa0-b686-6f8872243174" />

<img width="622" height="399" alt="Screenshot 2026-03-16 at 6 44 50 PM" src="https://github.com/user-attachments/assets/ac6b78ba-8a7e-4ce1-8e83-a871e4a79695" />

Enter and clicking away saves the name change, and pressing escape cancels the edit.

Resolves #387. 