### PR TITLE
Staging for release: v0.2.4 + Unreleased Changes

### DIFF
--- a/changelogs/latest.md
+++ b/changelogs/latest.md
@@ -20,6 +20,7 @@
 
 
 #### Fixed Bugs
+* Fix detach reactivity bug by [@jmdowrick](https://github.com/jmdowrick) in [#408](https://github.com/physiomelinks/phlynx/pull/408)
 * Ensure variables are added to user module configs by [@jmdowrick](https://github.com/jmdowrick) in [#396](https://github.com/physiomelinks/phlynx/pull/396)
 * Fix module replace dialog size by [@jmdowrick](https://github.com/jmdowrick) in [#395](https://github.com/physiomelinks/phlynx/pull/395)
 * Fix cellml export for constants by [@jmdowrick](https://github.com/jmdowrick) in [#393](https://github.com/physiomelinks/phlynx/pull/393)

--- a/docs/reference/change-log.md
+++ b/docs/reference/change-log.md
@@ -22,6 +22,7 @@
 
 
 #### Fixed Bugs
+* Fix detach reactivity bug by [@jmdowrick](https://github.com/jmdowrick) in [#408](https://github.com/physiomelinks/phlynx/pull/408)
 * Ensure variables are added to user module configs by [@jmdowrick](https://github.com/jmdowrick) in [#396](https://github.com/physiomelinks/phlynx/pull/396)
 * Fix module replace dialog size by [@jmdowrick](https://github.com/jmdowrick) in [#395](https://github.com/physiomelinks/phlynx/pull/395)
 * Fix cellml export for constants by [@jmdowrick](https://github.com/jmdowrick) in [#393](https://github.com/physiomelinks/phlynx/pull/393)

--- a/src/components/MacroBuilderDialog.vue
+++ b/src/components/MacroBuilderDialog.vue
@@ -93,6 +93,7 @@ import {
   GHOST_MODULE_FILENAME,
   markerEnd,
 } from '../utils/constants'
+import { detachReactivity } from '../utils/reactivity'
 
 const {
   addEdges,

--- a/src/views/BuilderView.vue
+++ b/src/views/BuilderView.vue
@@ -376,6 +376,7 @@ import {
 import { getId as getNextNodeId, generateUniqueModuleName } from '../utils/nodes'
 import { getId as getNextEdgeId } from '../utils/edges'
 import { getImportConfig, parseParametersFile } from '../utils/import'
+import { detachReactivity } from '../utils/reactivity'
 import {
   saveFileHandle, 
   saveWithDialog,
@@ -2164,8 +2165,8 @@ const copySelection = async () => {
   if (nodes.length === 0) return  
   
   const payload = {
-    nodes: detatchReactivity(nodes),
-    edges: detatchReactivity(edges),
+    nodes: detachReactivity(nodes),
+    edges: detachReactivity(edges),
   }
 
   clipboard.value = payload


### PR DESCRIPTION

## Unofficial Release
###### Includes changes up to 2026-03-23

#### Not Specified
* Bug fix code edit issue by [@jmdowrick](https://github.com/jmdowrick) in [#341](https://github.com/physiomelinks/phlynx/pull/341)
* Improve consistency of import dialog fields by [@jmdowrick](https://github.com/jmdowrick) in [#332](https://github.com/physiomelinks/phlynx/pull/332)
* Add missing units to the user units file by [@jmdowrick](https://github.com/jmdowrick) in [#313](https://github.com/physiomelinks/phlynx/pull/313)
* Add testing packages to phlynx by [@jmdowrick](https://github.com/jmdowrick) in [#308](https://github.com/physiomelinks/phlynx/pull/308)


#### New Features
* Introduce edge connection dialogue by [@jmdowrick](https://github.com/jmdowrick) in [#392](https://github.com/physiomelinks/phlynx/pull/392)
* Enable users to copy between windows by [@jmdowrick](https://github.com/jmdowrick) in [#399](https://github.com/physiomelinks/phlynx/pull/399)
* Add editable title to the application header by [@jmdowrick](https://github.com/jmdowrick) in [#397](https://github.com/physiomelinks/phlynx/pull/397)
* Introduce the ability to import modularised cellml files by [@jmdowrick](https://github.com/jmdowrick) in [#365](https://github.com/physiomelinks/phlynx/pull/365)
* Change shortcut intercepts when in text editor by [@jmdowrick](https://github.com/jmdowrick) in [#357](https://github.com/physiomelinks/phlynx/pull/357)
* Add reset view to right click menu by [@jmdowrick](https://github.com/jmdowrick) in [#338](https://github.com/physiomelinks/phlynx/pull/338)
* Introduce the ability to import multiple files by [@jmdowrick](https://github.com/jmdowrick) in [#316](https://github.com/physiomelinks/phlynx/pull/316)


#### Fixed Bugs
* Fix detach reactivity bug by [@jmdowrick](https://github.com/jmdowrick) in [#408](https://github.com/physiomelinks/phlynx/pull/408)
* Ensure variables are added to user module configs by [@jmdowrick](https://github.com/jmdowrick) in [#396](https://github.com/physiomelinks/phlynx/pull/396)
* Fix module replace dialog size by [@jmdowrick](https://github.com/jmdowrick) in [#395](https://github.com/physiomelinks/phlynx/pull/395)
* Fix cellml export for constants by [@jmdowrick](https://github.com/jmdowrick) in [#393](https://github.com/physiomelinks/phlynx/pull/393)
* Fix multiport handling bug by [@jmdowrick](https://github.com/jmdowrick) in [#381](https://github.com/physiomelinks/phlynx/pull/381)
* Fix naming of parseCellmlConnections by [@jmdowrick](https://github.com/jmdowrick) in [#376](https://github.com/physiomelinks/phlynx/pull/376)
* Fix file naming issue by [@jmdowrick](https://github.com/jmdowrick) in [#374](https://github.com/physiomelinks/phlynx/pull/374)
* Fix user module config index handling  by [@jmdowrick](https://github.com/jmdowrick) in [#368](https://github.com/physiomelinks/phlynx/pull/368)
* Change order of CellML export checks. by [@hsorby](https://github.com/hsorby) in [#363](https://github.com/physiomelinks/phlynx/pull/363)
* Change shortcut intercepts when in text editor by [@jmdowrick](https://github.com/jmdowrick) in [#357](https://github.com/physiomelinks/phlynx/pull/357)
* Ensure units update following cellml edit by [@jmdowrick](https://github.com/jmdowrick) in [#350](https://github.com/physiomelinks/phlynx/pull/350)
* Fix cellml module save behaviour by [@jmdowrick](https://github.com/jmdowrick) in [#349](https://github.com/physiomelinks/phlynx/pull/349)
* Fix cellml editing behaviour by [@jmdowrick](https://github.com/jmdowrick) in [#339](https://github.com/physiomelinks/phlynx/pull/339)
* Update import dialog to Hugh's liking by [@jmdowrick](https://github.com/jmdowrick) in [#331](https://github.com/physiomelinks/phlynx/pull/331)
* Ensure that warning dialog checks against the same store by [@jmdowrick](https://github.com/jmdowrick) in [#328](https://github.com/physiomelinks/phlynx/pull/328)
* Fix form behaviour by [@jmdowrick](https://github.com/jmdowrick) in [#325](https://github.com/physiomelinks/phlynx/pull/325)
* Fix vessel array file removal bug by [@jmdowrick](https://github.com/jmdowrick) in [#320](https://github.com/physiomelinks/phlynx/pull/320)
* Introduce the ability to import multiple files by [@jmdowrick](https://github.com/jmdowrick) in [#316](https://github.com/physiomelinks/phlynx/pull/316)
* Fix bugs related to system dialog by [@jmdowrick](https://github.com/jmdowrick) in [#307](https://github.com/physiomelinks/phlynx/pull/307)
* Fix order of columns in parameter export by [@jmdowrick](https://github.com/jmdowrick) in [#294](https://github.com/physiomelinks/phlynx/pull/294)
* Fix circulatory autogen export naming by [@jmdowrick](https://github.com/jmdowrick) in [#291](https://github.com/physiomelinks/phlynx/pull/291)
* Fix parameter export format by [@jmdowrick](https://github.com/jmdowrick) in [#287](https://github.com/physiomelinks/phlynx/pull/287)


#### Maintenance Work
* Introduce edge connection dialogue by [@jmdowrick](https://github.com/jmdowrick) in [#392](https://github.com/physiomelinks/phlynx/pull/392)
* Improve UX for multiport sum by [@jmdowrick](https://github.com/jmdowrick) in [#384](https://github.com/physiomelinks/phlynx/pull/384)
* Handle non-standard units requiring affine transform by [@jmdowrick](https://github.com/jmdowrick) in [#370](https://github.com/physiomelinks/phlynx/pull/370)
* Combine unit and module file imports by [@jmdowrick](https://github.com/jmdowrick) in [#359](https://github.com/physiomelinks/phlynx/pull/359)
* Improve module list ux by [@jmdowrick](https://github.com/jmdowrick) in [#352](https://github.com/physiomelinks/phlynx/pull/352)
* Make module creation easier by [@jmdowrick](https://github.com/jmdowrick) in [#334](https://github.com/physiomelinks/phlynx/pull/334)


#### Contributors

<kbd>
  <a href="https://github.com/jmdowrick">
    <img src="https://avatars.githubusercontent.com/u/146781982?u=94c7295b017c61161e81ba34c929524b31a423c2&v=4&s=100" width="50" height="50"><br>
    <sub>@jmdowrick</sub>
  </a>
</kbd> <kbd>
  <a href="https://github.com/hsorby">
    <img src="https://avatars.githubusercontent.com/u/778048?u=31d6ee5b17c95630c61a61e7cfe0c008b138b769&v=4&s=100" width="50" height="50"><br>
    <sub>@hsorby</sub>
  </a>
</kbd>