### PR TITLE
Introduce hover based handle addition

### DIFF
--- a/src/components/GhostNode.vue
+++ b/src/components/GhostNode.vue
@@ -95,7 +95,7 @@ watch(
   background: transparent;
   border: none;
   opacity: 0;
-  pointer-events: auto;
+  pointer-events: none;
 }
 
 .vue-flow__handle.handle--ghost.valid {

--- a/src/components/GhostNode.vue
+++ b/src/components/GhostNode.vue
@@ -16,14 +16,15 @@
       <!-- <button debug>Debug</button>  -->
     </Card>
 
-    <template v-for="handle in targetHandles" :key="handle.uid" class="handle">
+    <template v-for="handle in targetHandles" :key="handle.uid">
       <Handle
         :id="getHandleId(handle)"
         :position="handlePosition(handle.side)"
+        :class="['handle', `handle--${handle.variant || 'default'}`]"
         :style="getHandleStyle(handle, targetHandles)"
-        class="port-handle"
-      />
-    </template>
+      >
+      </Handle>
+  </template>
   </div>
 </template>
 
@@ -71,6 +72,31 @@ const nodeStyle = computed(() => {
 </script>
 
 <style scoped>
+.vue-flow__handle.handle--default {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--p-text-color);
+  opacity: 1;
+}
+
+.vue-flow__handle.handle--ghost {
+  width: 25px;
+  height: 25px;
+  border-radius: 50%;
+  background: transparent;
+  border: none;
+  opacity: 0;
+  pointer-events: auto;
+}
+
+.vue-flow__handle.handle--ghost.valid {
+  background-color: rgba(34, 197, 94, 0.15);
+  border-color: #22c55e;  
+  border-style: solid;
+  opacity: 1;
+}
+
 /* Visual styling to make it look "Ghostly" */
 .ghost-card {
   --p-card-color: #1f2937;

--- a/src/components/GhostNode.vue
+++ b/src/components/GhostNode.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, watch, nextTick } from 'vue'
 
 import Card from 'primevue/card'
 
@@ -37,7 +37,7 @@ import { useVueFlow, Handle } from '@vue-flow/core'
 import { getHandleId, getHandleStyle, handlePosition } from '../utils/handles'
 
 const props = defineProps(['id', 'data'])
-const { findNode } = useVueFlow()
+const { findNode, updateNodeInternals } = useVueFlow()
 
 const ghostLabel = computed(() => {
   return `${props.data.mathRef.split(':')[1]} [${props.data.mathRef.split(':')[0]}]`
@@ -69,6 +69,14 @@ const nodeStyle = computed(() => {
     height: `${node.dimensions.height}px`,
   }
 })
+
+watch(
+  targetHandles,
+  async () => {
+    await nextTick() 
+    updateNodeInternals([props.id])
+  }
+)
 </script>
 
 <style scoped>

--- a/src/components/GhostNode.vue
+++ b/src/components/GhostNode.vue
@@ -23,7 +23,7 @@
         :class="['handle', `handle--${handle.variant || 'default'}`]"
         :style="getHandleStyle(handle, targetHandles)"
       />
-  </template>
+    </template>
   </div>
 </template>
 

--- a/src/components/GhostNode.vue
+++ b/src/components/GhostNode.vue
@@ -22,8 +22,7 @@
         :position="handlePosition(handle.side)"
         :class="['handle', `handle--${handle.variant || 'default'}`]"
         :style="getHandleStyle(handle, targetHandles)"
-      >
-      </Handle>
+      />
   </template>
   </div>
 </template>

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -132,7 +132,7 @@ import Menu from 'primevue/menu'
 import CellMLIcon from './icons/CellMLIcon.vue'
 import { useLibraryStore } from '../stores/libraryStore'
 import { useFlowHistoryStore } from '../stores/historyStore'
-import { getHandleId, getHandleStyle, handlePosition } from '../utils/handles'
+import { getHandleId, getHandleStyle, handlePosition, findMostCentralGhostHandle } from '../utils/handles'
 import { sanitiseName } from '../utils/nodes'
 import { notify } from '../utils/notify'
 import { isEditableVariableType, isEmpty } from '../utils/variables'
@@ -334,21 +334,7 @@ async function removeHandle(handleIdToRemove) {
 }
 
 const addHandle = async (handleToAdd) => {
-  const handlesOnSide = props.data.handles.filter((h) => h.side === handleToAdd.side)
-  const center = (handlesOnSide.length - 1) / 2
-
-  let mostCentralGhost = null
-  let smallestDistance = Infinity
-
-  handlesOnSide.forEach((h, index) => {
-    if (h.variant !== HANDLE_VARIANT.GHOST) return
-
-    const distance = Math.abs(index - center)
-    if (distance < smallestDistance) {
-      smallestDistance = distance
-      mostCentralGhost = h
-    }
-  })
+  const mostCentralGhost = findMostCentralGhostHandle(handleToAdd.side, props.data.handles)
 
   if (!mostCentralGhost) {
     return
@@ -426,8 +412,8 @@ function openContextMenu(event) {
 }
 
 .vue-flow__handle.handle--ghost {
-  width: 30px;
-  height: 30px;
+  width: 25px;
+  height: 25px;
   border-radius: 50%;
   background: transparent;
   border: none;

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -425,8 +425,8 @@ function openContextMenu(event) {
 }
 
 .vue-flow__handle.handle--ghost {
-  width: 40px;
-  height: 40px;
+  width: 30px;
+  height: 30px;
   border-radius: 50%;
   background: transparent;
   border: none;
@@ -441,6 +441,7 @@ function openContextMenu(event) {
   border-style: solid;
   opacity: 1;
 }
+
 .instance-name {
   min-height: 2.5rem; 
   display: flex;

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -97,7 +97,7 @@
         :id="getHandleId(handle)"
         :ref="'handle_' + handle.side + '_' + handle.uid"
         :position="handlePosition(handle.side)"
-        class="handle"
+        :class="['handle', `handle--${handle.variant || 'default'}`]"
         :style="getHandleStyle(handle, data.handles)"
         v-tooltip.bottom="{ value: handle.name, showDelay: 1000 }"
         @mouseenter="onHandleEnter(handle.uid)"
@@ -224,9 +224,11 @@ function handleSetDomainType(newType) {
 }
 
 const domainMenuRef = ref(null)
+
 function toggleDomainMenu(event) {
   domainMenuRef.value?.toggle(event)
 }
+
 const domainTypeMenuItems = [
   { label: 'Membrane', command: () => handleSetDomainType('membrane') },
   { label: 'Process', command: () => handleSetDomainType('process') },
@@ -237,9 +239,11 @@ const domainTypeMenuItems = [
 ]
 
 const portMenuRef = ref(null)
+
 function togglePortMenu(event) {
   portMenuRef.value?.toggle(event)
 }
+
 const portMenuItems = [
   { label: 'Left', command: () => addHandle({ side: 'left' }) },
   { label: 'Right', command: () => addHandle({ side: 'right' }) },
@@ -407,12 +411,31 @@ function openContextMenu(event) {
 <style lang="scss" scoped>
 @import '../assets/vueflowhandle.css';
 
-.handle {
-  width: 14px !important;
-  height: 14px !important;
-  border-radius: 50% !important; 
+.vue-flow__handle.handle--default {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--p-text-color);
+  opacity: 1;
 }
 
+.vue-flow__handle.handle--ghost {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: transparent;
+  border: none;
+  opacity: 0;
+  pointer-events: auto;
+}
+
+.vue-flow__handle.handle--ghost:hover,
+.vue-flow__handle.handle--ghost.valid {
+  background-color: rgba(34, 197, 94, 0.15);
+  border-color: #22c55e;  
+  border-style: solid;
+  opacity: 1;
+}
 .instance-name {
   min-height: 2.5rem; 
   display: flex;

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -305,7 +305,9 @@ async function removeHandle(handleIdToRemove) {
   const edgesSnapshot = connectedEdges.map((edge) => detachReactivity(edge))
 
   // Define New Handles (for Redo)
-  const newHandles = props.data.handles.filter((h) => h.uid !== handleIdToRemove)
+  const newHandles = props.data.handles.map(
+    (h) => h.uid === handleIdToRemove ? { ...h, variant: HANDLE_VARIANT.GHOST } : h
+  )
 
   // Add Composite Command to History
   historyStore.executeAndAddCommand({

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -105,7 +105,7 @@
         @pointerdown="handle.variant === HANDLE_VARIANT.GHOST && activateHandle(props.id, handle.uid)"
       >
         <Button
-          v-show="hoveredHandleUid === handle.uid"
+          v-show="hoveredHandleUid === handle.uid && handle.variant !== HANDLE_VARIANT.GHOST"
           :class="['delete-handle-popover-btn', 'popover-' + handle.side]"
           icon="pi pi-trash"
           severity="danger"

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -289,7 +289,7 @@ function onHandleLeave() {
 async function removeHandle(handleIdToRemove) {
   const oldHandles = detachReactivity(props.data.handles)
 
-  const handle = oldHandles.find((p) => p.uid === handleIdToRemove)
+  const handle = oldHandles.find((h) => h.uid === handleIdToRemove)
   if (!handle) return
 
   const handleId = getHandleId(handle)
@@ -334,26 +334,8 @@ async function removeHandle(handleIdToRemove) {
 }
 
 const addHandle = async (handleToAdd) => {
-  const oldHandles = [...props.data.handles]
-
-  const newHandle = {
-    ...handleToAdd,
-    uid: crypto.randomUUID(),
-  }
-
-  const newHandles = [...props.data.handles, newHandle]
-
-  await applyHandles(newHandles)
-
-  historyStore.addCommand({
-    type: 'add-handle',
-    undo: async () => {
-      applyHandles(oldHandles)
-    },
-    redo: async () => {
-      applyHandles(newHandles)
-    },
-  })
+  const handle = props.data.handles.find((h) => h.side === handleToAdd.side && h.variant === HANDLE_VARIANT.GHOST)
+  activateHandle(props.id, handle.uid)
 }
 
 const isEditing = ref(false)

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -334,8 +334,27 @@ async function removeHandle(handleIdToRemove) {
 }
 
 const addHandle = async (handleToAdd) => {
-  const handle = props.data.handles.find((h) => h.side === handleToAdd.side && h.variant === HANDLE_VARIANT.GHOST)
-  activateHandle(props.id, handle.uid)
+  const handlesOnSide = props.data.handles.filter((h) => h.side === handleToAdd.side)
+  const center = (handlesOnSide.length - 1) / 2
+
+  let mostCentralGhost = null
+  let smallestDistance = Infinity
+
+  handlesOnSide.forEach((h, index) => {
+    if (h.variant !== HANDLE_VARIANT.GHOST) return
+
+    const distance = Math.abs(index - center)
+    if (distance < smallestDistance) {
+      smallestDistance = distance
+      mostCentralGhost = h
+    }
+  })
+
+  if (!mostCentralGhost) {
+    return
+  }
+
+  await activateHandle(props.id, mostCentralGhost.uid)
 }
 
 const isEditing = ref(false)

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -102,7 +102,7 @@
         v-tooltip.bottom="{ value: handle.name, showDelay: 1000 }"
         @mouseenter="onHandleEnter(handle.uid)"
         @mouseleave="onHandleLeave"
-        @pointerdown="handle.variant === HANDLE_VARIANT.GHOST && activateHandle(props.id, handle.uid)"
+        @pointerdown="handle.variant === HANDLE_VARIANT.GHOST && beginGhostActivation(props.id, handle.uid)"
       >
         <Button
           v-show="hoveredHandleUid === handle.uid && handle.variant !== HANDLE_VARIANT.GHOST"
@@ -142,7 +142,7 @@ import { TARGET_HANDLE_TYPE, SOURCE_HANDLE_TYPE, HANDLE_VARIANT } from '../utils
 import { useHandleActivation } from '../composables/useHandleActivation'
 
 const { addEdges, edges, removeEdges, updateNodeData, updateNodeInternals, nodes } = useVueFlow()
-const { activateHandle } = useHandleActivation()
+const { beginGhostActivation } = useHandleActivation()
 const historyStore = useFlowHistoryStore()
 const libraryStore = useLibraryStore()
 

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -142,7 +142,7 @@ import { TARGET_HANDLE_TYPE, SOURCE_HANDLE_TYPE, HANDLE_VARIANT } from '../utils
 import { useHandleActivation } from '../composables/useHandleActivation'
 
 const { addEdges, edges, removeEdges, updateNodeData, updateNodeInternals, nodes } = useVueFlow()
-const { beginGhostActivation } = useHandleActivation()
+const { beginGhostActivation, activateHandle } = useHandleActivation()
 const historyStore = useFlowHistoryStore()
 const libraryStore = useLibraryStore()
 

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -102,6 +102,7 @@
         v-tooltip.bottom="{ value: handle.name, showDelay: 1000 }"
         @mouseenter="onHandleEnter(handle.uid)"
         @mouseleave="onHandleLeave"
+        @pointerdown="handle.variant === HANDLE_VARIANT.GHOST && activateHandle(props.id, handle.uid)"
       >
         <Button
           v-show="hoveredHandleUid === handle.uid"
@@ -137,9 +138,11 @@ import { notify } from '../utils/notify'
 import { isEditableVariableType, isEmpty } from '../utils/variables'
 import '../assets/vueflownode.css'
 import { detachReactivity } from '../utils/reactivity'
-import { TARGET_HANDLE_TYPE, SOURCE_HANDLE_TYPE } from '../utils/constants'
+import { TARGET_HANDLE_TYPE, SOURCE_HANDLE_TYPE, HANDLE_VARIANT } from '../utils/constants'
+import { useHandleActivation } from '../composables/useHandleActivation'
 
 const { addEdges, edges, removeEdges, updateNodeData, updateNodeInternals, nodes } = useVueFlow()
+const { activateHandle } = useHandleActivation()
 const historyStore = useFlowHistoryStore()
 const libraryStore = useLibraryStore()
 

--- a/src/components/MacroBuilderDialog.vue
+++ b/src/components/MacroBuilderDialog.vue
@@ -85,6 +85,7 @@ import {
   GHOST_MODULE_DEFINITION,
   GHOST_MODULE_FILENAME,
   GHOST_MODULE_REF,
+  GHOST_NODE_TYPE,
   MACRO_BUILDER_ARROW,
   markerEnd,
 } from '../utils/constants'
@@ -131,11 +132,17 @@ onConnect((connection) => {
 
   confirmActivation()
   if (connection.sourceHandle) {
-    activateHandle(connection.target, getHandleUidFromHandleId(connection.source))
+    activateHandle(connection.source, getHandleUidFromHandleId(connection.sourceHandle))
   }
 
-  if (connection.targetHandle) {
-    activateHandle(connection.source, getHandleUidFromHandleId(connection.targetHandle))
+  if (connection.targetHandle) { 
+    const targetNode = findNode(connection.target)
+    console.log(targetNode)
+    if (targetNode.type === GHOST_NODE_TYPE) {
+      activateHandle(connection.source, getHandleUidFromHandleId(connection.targetHandle))
+    } else {
+      activateHandle(connection.target, getHandleUidFromHandleId(connection.targetHandle))
+    }
   }
 
   // Match what we specify in connectionLineOptions.

--- a/src/components/MacroBuilderDialog.vue
+++ b/src/components/MacroBuilderDialog.vue
@@ -77,6 +77,7 @@ import GhostSetupModal from './GhostSetupDialog.vue'
 import { useLibraryStore } from '../stores/libraryStore'
 import { useGtm } from '../composables/useGtm'
 import useDragAndDrop from '../composables/useDnD'
+import { useHandleActivation } from '../composables/useHandleActivation'
 import {
   edgeLineOptions,
   FLOW_IDS,
@@ -88,13 +89,16 @@ import {
   markerEnd,
 } from '../utils/constants'
 import { detachReactivity } from '../utils/reactivity'
+import { getHandleUidFromHandleId } from '../utils/handles.js'
 
-const { addEdges, edges, findNode, nodes, onConnect, onDragLeave, onNodeChange, onEdgeChange, removeNodes } =
+const { addEdges, edges, findNode, nodes, onConnect, onConnectEnd, onDragLeave, onNodeChange, onEdgeChange, removeNodes } =
   useVueFlow(FLOW_IDS.MACRO)
 
 const previousNodes = new Set()
 const { onDrop, isGhostSetupOpen, pendingGhostNodeId } = useDragAndDrop(previousNodes)
 const { trackEvent } = useGtm()
+
+const { revertPendingGhostIfUnused, confirmActivation, activateHandle } = useHandleActivation()
 
 const libraryStore = useLibraryStore()
 
@@ -124,6 +128,16 @@ const macroEdgeOptions = {
 }
 
 onConnect((connection) => {
+
+  confirmActivation()
+  if (connection.sourceHandle) {
+    activateHandle(connection.target, getHandleUidFromHandleId(connection.source))
+  }
+
+  if (connection.targetHandle) {
+    activateHandle(connection.source, getHandleUidFromHandleId(connection.targetHandle))
+  }
+
   // Match what we specify in connectionLineOptions.
   const newEdge = {
     ...connection,
@@ -131,6 +145,10 @@ onConnect((connection) => {
   }
 
   addEdges(newEdge)
+})
+
+onConnectEnd(() => {
+  revertPendingGhostIfUnused()
 })
 
 function onOpenEditDialog(eventPayload) {

--- a/src/components/MacroBuilderDialog.vue
+++ b/src/components/MacroBuilderDialog.vue
@@ -137,7 +137,6 @@ onConnect((connection) => {
 
   if (connection.targetHandle) { 
     const targetNode = findNode(connection.target)
-    console.log(targetNode)
     if (targetNode.type === GHOST_NODE_TYPE) {
       activateHandle(connection.source, getHandleUidFromHandleId(connection.targetHandle))
     } else {

--- a/src/composables/useDnD.js
+++ b/src/composables/useDnD.js
@@ -1,6 +1,6 @@
 import { useVueFlow } from '@vue-flow/core'
 import { ref, shallowRef, watch } from 'vue'
-import { GHOST_MODULE_FILENAME, GHOST_NODE_TYPE, MAIN_NODE_TYPE } from '../utils/constants'
+import { GHOST_MODULE_FILENAME, GHOST_NODE_TYPE, MAIN_NODE_TYPE, NUM_GHOST_HANDLES } from '../utils/constants'
 import { getId as getNextNodeId } from '../utils/nodes'
 import { generateUniqueInstanceName, findAnyNode } from '../utils/nodes'
 import { buildInstance } from '../services/import/buildWorkflow'
@@ -88,8 +88,8 @@ export default function useDragAndDrop(pendingHistoryNodes) {
     const instanceName = moduleData.moduleRef.includes(":") ? moduleData.moduleRef.split(":")[0] : moduleData.moduleRef
     const finalName = generateUniqueInstanceName(instanceName, existingNames)
 
-    const allHandles = [...handles, ...buildGhostHandles(16)]
-    
+    const allHandles = [...handles, ...buildGhostHandles(NUM_GHOST_HANDLES)]
+
     const componentFile = moduleData.mathRef.split(":")[0]
     const nodeType = componentFile === GHOST_MODULE_FILENAME ? GHOST_NODE_TYPE : MAIN_NODE_TYPE
     

--- a/src/composables/useDnD.js
+++ b/src/composables/useDnD.js
@@ -1,6 +1,12 @@
 import { useVueFlow } from '@vue-flow/core'
 import { ref, shallowRef, watch } from 'vue'
-import { GHOST_MODULE_FILENAME, GHOST_NODE_TYPE, MAIN_NODE_TYPE, NUM_GHOST_HANDLES } from '../utils/constants'
+import {
+  GHOST_MODULE_FILENAME,
+  GHOST_NODE_TYPE,
+  MAIN_NODE_TYPE,
+  NUM_GHOST_HANDLES_SIDES,
+  NUM_GHOST_HANDLES_TOP_BOT
+} from '../utils/constants'
 import { getId as getNextNodeId } from '../utils/nodes'
 import { generateUniqueInstanceName, findAnyNode } from '../utils/nodes'
 import { buildInstance } from '../services/import/buildWorkflow'
@@ -88,7 +94,7 @@ export default function useDragAndDrop(pendingHistoryNodes) {
     const instanceName = moduleData.moduleRef.includes(":") ? moduleData.moduleRef.split(":")[0] : moduleData.moduleRef
     const finalName = generateUniqueInstanceName(instanceName, existingNames)
 
-    const allHandles = [...handles, ...buildGhostHandles(NUM_GHOST_HANDLES)]
+    const allHandles = [...handles, ...buildGhostHandles(NUM_GHOST_HANDLES_TOP_BOT, NUM_GHOST_HANDLES_SIDES)]
 
     const componentFile = moduleData.mathRef.split(":")[0]
     const nodeType = componentFile === GHOST_MODULE_FILENAME ? GHOST_NODE_TYPE : MAIN_NODE_TYPE

--- a/src/composables/useDnD.js
+++ b/src/composables/useDnD.js
@@ -4,6 +4,7 @@ import { GHOST_MODULE_FILENAME, GHOST_NODE_TYPE, MAIN_NODE_TYPE } from '../utils
 import { getId as getNextNodeId } from '../utils/nodes'
 import { generateUniqueInstanceName, findAnyNode } from '../utils/nodes'
 import { buildInstance } from '../services/import/buildWorkflow'
+import { buildGhostHandles } from '../utils/handles'
 
 /**
  * In a real world scenario you'd want to avoid creating refs in a global scope like this as they might not be cleaned up properly.
@@ -87,10 +88,12 @@ export default function useDragAndDrop(pendingHistoryNodes) {
     const instanceName = moduleData.moduleRef.includes(":") ? moduleData.moduleRef.split(":")[0] : moduleData.moduleRef
     const finalName = generateUniqueInstanceName(instanceName, existingNames)
 
+    const allHandles = [...handles, ...buildGhostHandles(16)]
+    
     const componentFile = moduleData.mathRef.split(":")[0]
     const nodeType = componentFile === GHOST_MODULE_FILENAME ? GHOST_NODE_TYPE : MAIN_NODE_TYPE
     
-    const newNode = buildInstance(nodeId, finalName, nodeType, moduleData, handles, position)
+    const newNode = buildInstance(nodeId, finalName, nodeType, moduleData, allHandles, position)
 
     /**
      * Align node position after drop, so it's centered to the mouse.

--- a/src/composables/useHandleActivation.js
+++ b/src/composables/useHandleActivation.js
@@ -1,23 +1,26 @@
-import { nextTick } from 'vue'
+import { nextTick, ref } from 'vue'
 import { useVueFlow } from '@vue-flow/core'
 import { useFlowHistoryStore } from '../stores/historyStore'
 import { HANDLE_VARIANT } from '../utils/constants'
+import { getHandleId } from '../utils/handles'
 import { detachReactivity } from '../utils/reactivity'
 
+const pendingGhostRevert = ref(null)
+
 export function useHandleActivation() {
-  const { getNodes, updateNodeData, updateNodeInternals } = useVueFlow()
+  const { getNodes, updateNodeData, updateNodeInternals, edges } = useVueFlow()
   const historyStore = useFlowHistoryStore()
 
-  async function activateHandle(nodeId, handleUid) {
+  async function setHandleVariant(nodeId, handleUid, variant) {
     const node = getNodes.value.find((n) => n.id === nodeId)
     if (!node) return
 
     const handle = node.data.handles.find((h) => h.uid === handleUid)
-    if (!handle || handle.variant !== HANDLE_VARIANT.GHOST) return
+    if (!handle || handle.variant === variant) return
 
     const oldHandles = detachReactivity(node.data.handles)
     const newHandles = node.data.handles.map((h) =>
-      h.uid === handleUid ? { ...h, variant: HANDLE_VARIANT.DEFAULT } : h
+      h.uid === handleUid ? { ...h, variant } : h
     )
 
     const apply = async (handles) => {
@@ -29,11 +32,51 @@ export function useHandleActivation() {
     await apply(newHandles)
 
     historyStore.addCommand({
-      type: 'activate-ghost-handle',
+      type: `set-handle-variant-${variant}`,
       undo: () => apply(oldHandles),
       redo: () => apply(newHandles),
     })
   }
 
-  return { activateHandle }
+  async function activateHandle(nodeId, handleUid) {
+    await setHandleVariant(nodeId, handleUid, HANDLE_VARIANT.DEFAULT)
+  }
+
+  function beginGhostActivation(nodeId, handleUid) {
+    pendingGhostRevert.value = { nodeId, handleUid }
+    activateHandle(nodeId, handleUid)
+  }
+
+  function confirmActivation() {
+    pendingGhostRevert.value = null
+  }
+
+  async function revertPendingGhostIfUnused() {
+    if (!pendingGhostRevert.value) return
+
+    const { nodeId, handleUid } = pendingGhostRevert.value
+    pendingGhostRevert.value = null
+
+    const node = getNodes.value.find((n) => n.id === nodeId)
+    const handle = node?.data.handles.find((h) => h.uid === handleUid)
+    if (!handle) return
+
+    const handleId = getHandleId(handle)
+    const hasEdge = edges.value.some(
+      (edge) =>
+        (edge.source === nodeId && edge.sourceHandle === handleId) ||
+        (edge.target === nodeId && edge.targetHandle === handleId)
+    )
+
+    if (!hasEdge) {
+      await setHandleVariant(nodeId, handleUid, HANDLE_VARIANT.GHOST)
+    }
+  }
+
+  return {
+    activateHandle,
+    beginGhostActivation,
+    confirmActivation,
+    revertPendingGhostIfUnused,
+  }
 }

--- a/src/composables/useHandleActivation.js
+++ b/src/composables/useHandleActivation.js
@@ -1,0 +1,39 @@
+import { nextTick } from 'vue'
+import { useVueFlow } from '@vue-flow/core'
+import { useFlowHistoryStore } from '../stores/historyStore'
+import { HANDLE_VARIANT } from '../utils/constants'
+import { detachReactivity } from '../utils/reactivity'
+
+export function useHandleActivation() {
+  const { getNodes, updateNodeData, updateNodeInternals } = useVueFlow()
+  const historyStore = useFlowHistoryStore()
+
+  async function activateHandle(nodeId, handleUid) {
+    const node = getNodes.value.find((n) => n.id === nodeId)
+    if (!node) return
+
+    const handle = node.data.handles.find((h) => h.uid === handleUid)
+    if (!handle || handle.variant !== HANDLE_VARIANT.GHOST) return
+
+    const oldHandles = detachReactivity(node.data.handles)
+    const newHandles = node.data.handles.map((h) =>
+      h.uid === handleUid ? { ...h, variant: HANDLE_VARIANT.DEFAULT } : h
+    )
+
+    const apply = async (handles) => {
+      updateNodeData(nodeId, { handles })
+      await nextTick()
+      updateNodeInternals(nodeId)
+    }
+
+    await apply(newHandles)
+
+    historyStore.addCommand({
+      type: 'activate-ghost-handle',
+      undo: () => apply(oldHandles),
+      redo: () => apply(newHandles),
+    })
+  }
+
+  return { activateHandle }
+}

--- a/src/services/import/buildPorts.js
+++ b/src/services/import/buildPorts.js
@@ -1,41 +1,5 @@
 import { SOURCE_HANDLE_TYPE, TARGET_HANDLE_TYPE } from "../../utils/constants"
 
-function parseInstanceNames(connectedInstances) {
-  return Array.from(
-    new Set(connectedInstances?.trim().split(/\s+/).filter(Boolean) ?? [])
-  )
-}
-
-function buildHandles(instance) {
-  const handles = []
-
-  if (instance.inp_instances) {
-    const inputs = parseInstanceNames(instance.inp_instances)
-    inputs.forEach((name) => {
-      handles.push({
-        uid: crypto.randomUUID(),
-        type: TARGET_HANDLE_TYPE,
-        side: 'left',
-        name,
-      })
-    })
-  }
-
-  if (instance.out_instances) {
-    const outputs = parseInstanceNames(instance.out_instances)
-    outputs.forEach((name) => {
-      handles.push({
-        uid: crypto.randomUUID(),
-        type: SOURCE_HANDLE_TYPE,
-        side: 'right',
-        name,
-      })
-    })
-  }
-
-  return handles
-}
-
 function buildPorts(moduleData) {
   return Object.entries(moduleData)
     .filter(
@@ -55,4 +19,4 @@ function buildPorts(moduleData) {
     )
 }
 
-export { buildPorts, buildHandles }
+export { buildPorts }

--- a/src/services/import/buildWorkflow.js
+++ b/src/services/import/buildWorkflow.js
@@ -1,4 +1,4 @@
-import { getHandleId, buildHandles } from '../../utils/handles'
+import { getHandleId, buildHandles, buildGhostHandles } from '../../utils/handles'
 import { MAIN_NODE_TYPE, SOURCE_HANDLE_TYPE, TARGET_HANDLE_TYPE } from '../../utils/constants'
 import { extractVariablesFromMath } from '../../utils/cellml'
 import { resolvePortCouplings, checkAndClaimCouplings, buildUsedPortKeys } from '../../utils/edges'
@@ -49,8 +49,9 @@ function buildInstances(instanceRefs, availableModules, currentNodes, progressCa
     }
 
     const nodeType = MAIN_NODE_TYPE
-    const handles = buildHandles(instanceRef)
-
+    const ghostHandles = buildGhostHandles()
+    const handles = buildHandles(instanceRef, ghostHandles)
+    
     let position = null
     if (instanceRef.x !== undefined && instanceRef.y !== undefined) {
       position = { x: instanceRef.x, y: instanceRef.y }

--- a/src/services/import/buildWorkflow.js
+++ b/src/services/import/buildWorkflow.js
@@ -1,5 +1,4 @@
-import { buildHandles } from './buildPorts'
-import { getHandleId } from '../../utils/handles'
+import { getHandleId, buildHandles } from '../../utils/handles'
 import { MAIN_NODE_TYPE, SOURCE_HANDLE_TYPE, TARGET_HANDLE_TYPE } from '../../utils/constants'
 import { extractVariablesFromMath } from '../../utils/cellml'
 import { resolvePortCouplings, checkAndClaimCouplings, buildUsedPortKeys } from '../../utils/edges'

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -2,6 +2,10 @@ import { MarkerType } from '@vue-flow/core'
 
 export const SOURCE_HANDLE_TYPE = 'source'
 export const TARGET_HANDLE_TYPE = 'target'
+export const HANDLE_VARIANT = {
+  DEFAULT: 'default', 
+  GHOST: 'ghost',      
+}
 export const USER_MODULES_FILE = 'User_Modules.cellml'
 export const NEW_INSTANCE_MODULE_REF = 'new_module:phlynx'
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -7,7 +7,7 @@ export const HANDLE_VARIANT = {
   GHOST: 'ghost',      
 }
 export const NUM_GHOST_HANDLES_SIDES = 4
-export const NUM_GHOST_HANDLES_TOP_BOT = 6
+export const NUM_GHOST_HANDLES_TOP_BOT = 8
 export const HANDLE_SPACING = 30
 
 export const USER_MODULES_FILE = 'User_Modules.cellml'

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -6,6 +6,8 @@ export const HANDLE_VARIANT = {
   DEFAULT: 'default', 
   GHOST: 'ghost',      
 }
+export const NUM_GHOST_HANDLES = 16
+
 export const USER_MODULES_FILE = 'User_Modules.cellml'
 export const NEW_INSTANCE_MODULE_REF = 'new_module:phlynx'
 
@@ -19,7 +21,6 @@ export const edgeLineOptions = {
   markerEnd: markerEnd,
   style: {
     strokeWidth: 5,
-    // stroke: '#b1b1b7', // Can customize color if desired.
   },
 }
 export const FLOW_IDS = {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -6,9 +6,9 @@ export const HANDLE_VARIANT = {
   DEFAULT: 'default', 
   GHOST: 'ghost',      
 }
-export const NUM_GHOST_HANDLES_SIDES = 4
-export const NUM_GHOST_HANDLES_TOP_BOT = 8
-export const HANDLE_SPACING = 30
+export const NUM_GHOST_HANDLES_SIDES = 5
+export const NUM_GHOST_HANDLES_TOP_BOT = 7
+export const HANDLE_SPACING = 25
 
 export const USER_MODULES_FILE = 'User_Modules.cellml'
 export const NEW_INSTANCE_MODULE_REF = 'new_module:phlynx'

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -6,7 +6,8 @@ export const HANDLE_VARIANT = {
   DEFAULT: 'default', 
   GHOST: 'ghost',      
 }
-export const NUM_GHOST_HANDLES = 16
+export const NUM_GHOST_HANDLES_SIDES = 4
+export const NUM_GHOST_HANDLES_TOP_BOT = 6
 export const HANDLE_SPACING = 30
 
 export const USER_MODULES_FILE = 'User_Modules.cellml'

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -7,6 +7,7 @@ export const HANDLE_VARIANT = {
   GHOST: 'ghost',      
 }
 export const NUM_GHOST_HANDLES = 16
+export const HANDLE_SPACING = 30
 
 export const USER_MODULES_FILE = 'User_Modules.cellml'
 export const NEW_INSTANCE_MODULE_REF = 'new_module:phlynx'

--- a/src/utils/handles.js
+++ b/src/utils/handles.js
@@ -95,15 +95,14 @@ export function buildHandles(instanceRef) {
   return handles
 }
 
-export function buildGhostHandles(count = 16) {
-  const perSide = Math.floor(count / HANDLE_SIDES.length)
-  const remainder = count % HANDLE_SIDES.length
-
+export function buildGhostHandles(countTopBot = 5, countSides = 4) {
   const handles = []
 
   HANDLE_SIDES.forEach((side, sideIndex) => {
-    // spread any remainder across the first few sides so odd counts still work
-    const n = perSide + (sideIndex < remainder ? 1 : 0)
+    let n = countTopBot
+    if (side === "left" || side === "right"){
+      n = countSides
+    }
 
     for (let i = 0; i < n; i++) {
       handles.push({

--- a/src/utils/handles.js
+++ b/src/utils/handles.js
@@ -1,5 +1,11 @@
 import { Position } from '@vue-flow/core'
-import { HANDLE_SIDES, SOURCE_HANDLE_PRIORITY, TARGET_HANDLE_PRIORITY } from './constants'
+import {
+  HANDLE_SIDES,
+  SOURCE_HANDLE_PRIORITY,
+  TARGET_HANDLE_PRIORITY,
+  TARGET_HANDLE_TYPE,
+  SOURCE_HANDLE_TYPE
+} from './constants'
 
 export function randomHandleSide() {
     return HANDLE_SIDES[Math.floor(Math.random() * HANDLE_SIDES.length)]
@@ -49,4 +55,41 @@ export function getHandleStyle(handle, allHandles) {
   return {
     top: `calc(50% + ${offset}px)`,
   }
+}
+
+
+function parseInstanceNames(connectedInstances) {
+  return Array.from(
+    new Set(connectedInstances?.trim().split(/\s+/).filter(Boolean) ?? [])
+  )
+}
+
+export function buildHandles(instance) {
+  const handles = []
+
+  if (instance.inp_instances) {
+    const inputs = parseInstanceNames(instance.inp_instances)
+    inputs.forEach((name) => {
+      handles.push({
+        uid: crypto.randomUUID(),
+        type: TARGET_HANDLE_TYPE,
+        side: 'left',
+        name,
+      })
+    })
+  }
+
+  if (instance.out_instances) {
+    const outputs = parseInstanceNames(instance.out_instances)
+    outputs.forEach((name) => {
+      handles.push({
+        uid: crypto.randomUUID(),
+        type: SOURCE_HANDLE_TYPE,
+        side: 'right',
+        name,
+      })
+    })
+  }
+
+  return handles
 }

--- a/src/utils/handles.js
+++ b/src/utils/handles.js
@@ -9,11 +9,15 @@ import {
 } from './constants'
 
 export function randomHandleSide() {
-    return HANDLE_SIDES[Math.floor(Math.random() * HANDLE_SIDES.length)]
+  return HANDLE_SIDES[Math.floor(Math.random() * HANDLE_SIDES.length)]
 }
 
 export function getHandleId(handle) {
-    return `handle_${handle.uid}`
+  return `handle_${handle.uid}`
+}
+
+export function getHandleUidFromHandleId(handleId) {
+  return handleId.replace("handle_", "")
 }
 
 export function handlePosition(side) {

--- a/src/utils/handles.js
+++ b/src/utils/handles.js
@@ -66,11 +66,18 @@ function parseInstanceNames(connectedInstances) {
   )
 }
 
-export function buildHandles(instance) {
+/**
+ * Creates a list of handles for an instance node given the instance ref 
+ * defined in an instance array file.
+ * 
+ * @param {object} instanceRef 
+ * @returns {[handle]} handle 
+ */
+export function buildHandles(instanceRef) {
   const handles = []
 
-  if (instance.inp_instances) {
-    const inputs = parseInstanceNames(instance.inp_instances)
+  if (instanceRef.inp_instances) {
+    const inputs = parseInstanceNames(instanceRef.inp_instances)
     inputs.forEach((name) => {
       handles.push({
         uid: crypto.randomUUID(),
@@ -81,8 +88,8 @@ export function buildHandles(instance) {
     })
   }
 
-  if (instance.out_instances) {
-    const outputs = parseInstanceNames(instance.out_instances)
+  if (instanceRef.out_instances) {
+    const outputs = parseInstanceNames(instanceRef.out_instances)
     outputs.forEach((name) => {
       handles.push({
         uid: crypto.randomUUID(),

--- a/src/utils/handles.js
+++ b/src/utils/handles.js
@@ -33,7 +33,7 @@ export function handlePosition(side) {
 
 export function getHandleStyle(handle, allHandles) {
   const handlesOfSameType = allHandles.filter(
-    (h) => h.side === handle.side && h.variant === handle.variant
+    (h) => h.side === handle.side 
   )
   const n = handlesOfSameType.length
 

--- a/src/utils/handles.js
+++ b/src/utils/handles.js
@@ -4,7 +4,8 @@ import {
   SOURCE_HANDLE_PRIORITY,
   TARGET_HANDLE_PRIORITY,
   TARGET_HANDLE_TYPE,
-  SOURCE_HANDLE_TYPE
+  SOURCE_HANDLE_TYPE,
+  HANDLE_VARIANT,
 } from './constants'
 
 export function randomHandleSide() {
@@ -31,7 +32,9 @@ export function handlePosition(side) {
 }
 
 export function getHandleStyle(handle, allHandles) {
-  const handlesOfSameType = allHandles.filter((h) => h.side === handle.side)
+  const handlesOfSameType = allHandles.filter(
+    (h) => h.side === handle.side && h.variant === handle.variant
+  )
   const n = handlesOfSameType.length
 
   // Space between each port.
@@ -56,7 +59,6 @@ export function getHandleStyle(handle, allHandles) {
     top: `calc(50% + ${offset}px)`,
   }
 }
-
 
 function parseInstanceNames(connectedInstances) {
   return Array.from(
@@ -90,6 +92,29 @@ export function buildHandles(instance) {
       })
     })
   }
+
+  return handles
+}
+
+export function buildGhostHandles(count = 16) {
+  const perSide = Math.floor(count / HANDLE_SIDES.length)
+  const remainder = count % HANDLE_SIDES.length
+
+  const handles = []
+
+  HANDLE_SIDES.forEach((side, sideIndex) => {
+    // spread any remainder across the first few sides so odd counts still work
+    const n = perSide + (sideIndex < remainder ? 1 : 0)
+
+    for (let i = 0; i < n; i++) {
+      handles.push({
+        uid: crypto.randomUUID(),
+        side,
+        name: '',
+        variant: HANDLE_VARIANT.GHOST,
+      })
+    }
+  })
 
   return handles
 }

--- a/src/utils/handles.js
+++ b/src/utils/handles.js
@@ -6,6 +6,7 @@ import {
   TARGET_HANDLE_TYPE,
   SOURCE_HANDLE_TYPE,
   HANDLE_VARIANT,
+  HANDLE_SPACING,
 } from './constants'
 
 export function randomHandleSide() {
@@ -36,32 +37,19 @@ export function handlePosition(side) {
 }
 
 export function getHandleStyle(handle, allHandles) {
-  const handlesOfSameType = allHandles.filter(
-    (h) => h.side === handle.side 
-  )
+  const handlesOfSameType = allHandles.filter((h) => h.side === handle.side)
   const n = handlesOfSameType.length
 
-  // Space between each port.
-  const handleSpacing = 16
   const positionIndex = handlesOfSameType.findIndex((h) => h.uid === handle.uid)
-
-  // guard: if not found, fall back to 0
   const safeIndex = positionIndex === -1 ? 0 : positionIndex
 
-  // This calculates the offset from the center
-  const offset = handleSpacing * (positionIndex - (n - 1) / 2)
+  const offset = HANDLE_SPACING * (safeIndex - (n - 1) / 2)
 
   if (['top', 'bottom'].includes(handle.side)) {
-    // Let CSS calculate the 50% mark and apply the offset
-    return {
-      left: `calc(50% + ${offset}px)`,
-    }
+    return { left: `calc(50% + ${offset}px)` }
   }
 
-  // Let CSS calculate the 50% mark and apply the offset
-  return {
-    top: `calc(50% + ${offset}px)`,
-  }
+  return { top: `calc(50% + ${offset}px)` }
 }
 
 function parseInstanceNames(connectedInstances) {

--- a/src/utils/handles.js
+++ b/src/utils/handles.js
@@ -58,44 +58,65 @@ function parseInstanceNames(connectedInstances) {
   )
 }
 
-/**
- * Creates a list of handles for an instance node given the instance ref 
- * defined in an instance array file.
- * 
- * @param {object} instanceRef 
- * @returns {[handle]} handle 
- */
-export function buildHandles(instanceRef) {
-  const handles = []
+export function findMostCentralGhostHandle(side, allHandles) {
+  const handlesOnSide = allHandles.filter((h) => h.side === side)
+  const center = (handlesOnSide.length - 1) / 2
 
-  if (instanceRef.inp_instances) {
-    const inputs = parseInstanceNames(instanceRef.inp_instances)
-    inputs.forEach((name) => {
-      handles.push({
-        uid: crypto.randomUUID(),
-        type: TARGET_HANDLE_TYPE,
-        side: 'left',
-        name,
-      })
+  let mostCentral = null
+  let smallestDistance = Infinity
+
+  handlesOnSide.forEach((h, index) => {
+    if (h.variant !== HANDLE_VARIANT.GHOST) return
+    const distance = Math.abs(index - center)
+    if (distance < smallestDistance) {
+      smallestDistance = distance
+      mostCentral = h
+    }
+  })
+
+  return mostCentral
+}
+
+export function buildHandles(instanceRef, ghostHandles) {
+  const handles = ghostHandles.map((h) => ({ ...h }))
+
+  const promote = (names, type, side) => {
+    names.forEach((name) => {
+      const ghost = findMostCentralGhostHandle(side, handles)
+
+      if (!ghost) {
+        console.warn(
+          `[buildHandles] No free "${side}" ghost slot for "${name}" on instance ` +
+            `"${instanceRef.name}" — exceeds the per-edge handle limit. Adding an overflow handle.`
+        )
+        handles.push({
+          uid: crypto.randomUUID(),
+          type,
+          side,
+          name,
+          variant: HANDLE_VARIANT.DEFAULT,
+        })
+        return
+      }
+
+      ghost.type = type
+      ghost.name = name
+      ghost.variant = HANDLE_VARIANT.DEFAULT
     })
   }
 
+  if (instanceRef.inp_instances) {
+    promote(parseInstanceNames(instanceRef.inp_instances), TARGET_HANDLE_TYPE, 'top')
+  }
+
   if (instanceRef.out_instances) {
-    const outputs = parseInstanceNames(instanceRef.out_instances)
-    outputs.forEach((name) => {
-      handles.push({
-        uid: crypto.randomUUID(),
-        type: SOURCE_HANDLE_TYPE,
-        side: 'right',
-        name,
-      })
-    })
+    promote(parseInstanceNames(instanceRef.out_instances), SOURCE_HANDLE_TYPE, 'bottom')
   }
 
   return handles
 }
 
-export function buildGhostHandles(countTopBot = 5, countSides = 4) {
+export function buildGhostHandles(countTopBot = 7, countSides = 5) {
   const handles = []
 
   HANDLE_SIDES.forEach((side, sideIndex) => {

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -465,6 +465,7 @@ const {
   getSelectedEdges,
   nodes,
   onConnect,
+  onConnectEnd,
   removeEdges,
   removeNodes,
   screenToFlowCoordinate,
@@ -487,7 +488,7 @@ const {
   createInstanceNode,
 } = useDragAndDrop(pendingHistoryNodes)
 
-const { activateHandle } = useHandleActivation()
+const { activateHandle, confirmActivation, revertPendingGhostIfUnused } = useHandleActivation()
 
 const dialogVisible = computed(() => {
   return (
@@ -853,6 +854,10 @@ const currentExportMode = computed(() => {
   return found || exportOptions.value[0]
 })
 
+onConnectEnd(() => {
+  revertPendingGhostIfUnused()
+})
+
 onConnect((connection) => {
   const sourceNode = findNode(connection.source)
   const targetNode = findNode(connection.target)
@@ -878,6 +883,7 @@ onConnect((connection) => {
     targetIndex
   )
 
+  confirmActivation()
   if (connection.sourceHandle) {
     activateHandle(connection.source, getHandleUidFromHandleId(connection.sourceHandle))
   }

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -379,6 +379,7 @@ import { MiniMap } from '@vue-flow/minimap'
 import { useLibraryStore } from '../stores/libraryStore'
 import { useFlowHistoryStore } from '../stores/historyStore'
 import useDragAndDrop from '../composables/useDnD'
+import { useHandleActivation } from '../composables/useHandleActivation'
 import { useLoadFromInstanceArray } from '../composables/useLoadFromInstanceArray'
 import { useLoadFromCellML } from '../composables/useLoadFromCellml'
 import { parseCellMLConnections } from '../services/import/parseCellmlConnections'
@@ -443,6 +444,7 @@ import CellMLEditorDialog from '../components/CellMLEditorDialog.vue'
 import ParameterEditorDialog from '../components/ParameterEditorDialog.vue'
 import PortEditorDialog from '../components/PortEditorDialog.vue'
 import CellMLIcon from '../components/icons/CellMLIcon.vue'
+import { getHandleId, getHandleUidFromHandleId } from '../utils/handles'
 
 const workspaceFileInput = ref(null)
 
@@ -484,6 +486,8 @@ const {
   isDragOver,
   createInstanceNode,
 } = useDragAndDrop(pendingHistoryNodes)
+
+const { activateHandle } = useHandleActivation()
 
 const dialogVisible = computed(() => {
   return (
@@ -873,6 +877,14 @@ onConnect((connection) => {
     sourceIndex,
     targetIndex
   )
+
+  if (connection.sourceHandle) {
+    activateHandle(connection.source, getHandleUidFromHandleId(connection.sourceHandle))
+  }
+
+  if (connection.targetHandle) {
+    activateHandle(connection.target, getHandleUidFromHandleId(connection.targetHandle))
+  }
 
   const newEdge = {
     ...connection,


### PR DESCRIPTION
Resolves #300 

Ended up starting again this morning and landed on a much simpler solution. Introduced a second handle variant (ghost) that becomes active on pointer down or on connect. Consolidated this activation into a composable that's called when adding a handle through the button on the instance node. 

Deleting handles also restores them to ghost mode. Activated ghost handles that don't become part of a connection are reverted to ghost handles on connect end.

Addressed most of the implications for the automated workflow builders, but updating the layout calculators was beyond me (sometimes the automated layouts aren't so nice because the handles get redistributed in a funky way). Might be worth resolving this before merging? But it could also be ok for now.