### PR TITLE
Introduce hover based handle addition and duplicate connection replacement dialog

### DIFF
--- a/src/components/ConfirmDialog.vue
+++ b/src/components/ConfirmDialog.vue
@@ -1,24 +1,22 @@
 <template>
   <ConfirmDialog group="app-confirm">
     <template #container="{ message, acceptCallback, rejectCallback }">
-      <div
-        class="w-[min(92vw,420px)] rounded-lg border border-surface-200 bg-surface-0 p-6 shadow-lg dark:border-surface-700 dark:bg-surface-900"
-      >
-        <div class="flex items-start gap-3">
-          <i :class="['text-2xl leading-none', getIcon(message.severity)]" />
+      <div class="confirm-container">
+        <div class="confirm-body">
+          <i :class="['confirm-icon', getIcon(message.severity)]" :style="{ color: getIconColor(message.severity) }" />
 
-          <div class="min-w-0 flex-1">
-            <div class="text-lg font-semibold text-surface-900 dark:text-surface-0">
+          <div class="confirm-text">
+            <div class="confirm-header">
               {{ message.header }}
             </div>
 
-            <div class="mt-2 whitespace-pre-wrap text-sm text-surface-700 dark:text-surface-300">
+            <div class="confirm-message">
               {{ message.message }}
             </div>
           </div>
         </div>
 
-        <div class="mt-6 flex justify-end gap-2">
+        <div class="confirm-actions">
           <Button
             v-if="message.rejectLabel"
             :label="message.rejectLabel"
@@ -45,16 +43,37 @@ import Button from 'primevue/button'
 function getIcon(severity?: string) {
   switch (severity) {
     case 'error':
-      return 'pi pi-times-circle text-red-500'
+      return 'pi pi-times-circle'
 
     case 'warning':
-      return 'pi pi-exclamation-triangle text-orange-500'
+      return 'pi pi-exclamation-triangle'
 
     case 'success':
-      return 'pi pi-check-circle text-green-500'
+      return 'pi pi-check-circle'
 
     default:
-      return 'pi pi-info-circle text-blue-500'
+      return 'pi pi-info-circle'
+  }
+}
+
+// Reads from PrimeVue's own theme tokens (with sensible fallbacks) rather than
+// hardcoded Tailwind palette classes, so these track whatever preset/colors
+// the app is actually themed with, and update automatically with PrimeVue's
+// dark-mode class toggle instead of depending on Tailwind's separate dark:
+// variant config staying in sync with it.
+function getIconColor(severity?: string) {
+  switch (severity) {
+    case 'error':
+      return 'var(--p-red-500, #ef4444)'
+
+    case 'warning':
+      return 'var(--p-orange-500, #f97316)'
+
+    case 'success':
+      return 'var(--p-green-500, #22c55e)'
+
+    default:
+      return 'var(--p-blue-500, #3b82f6)'
   }
 }
 
@@ -74,3 +93,50 @@ function getButtonSeverity(severity?: string) {
   }
 }
 </script>
+
+<style scoped>
+.confirm-container {
+  width: min(92vw, 420px);
+  border-radius: 8px;
+  padding: 24px;
+  border: 1px solid var(--p-content-border-color, #e5e7eb);
+  background: var(--p-content-background, #ffffff);
+  box-shadow: var(--p-overlay-modal-shadow, 0 4px 24px rgba(0, 0, 0, 0.15));
+}
+
+.confirm-body {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.confirm-icon {
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.confirm-text {
+  min-width: 0;
+  flex: 1;
+}
+
+.confirm-header {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--p-text-color, #18181b);
+}
+
+.confirm-message {
+  margin-top: 8px;
+  font-size: 0.875rem;
+  white-space: pre-wrap;
+  color: var(--p-text-muted-color, #52525b);
+}
+
+.confirm-actions {
+  margin-top: 24px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+</style>

--- a/src/components/GhostNode.vue
+++ b/src/components/GhostNode.vue
@@ -95,7 +95,7 @@ watch(
   background: transparent;
   border: none;
   opacity: 0;
-  pointer-events: auto;
+  pointer-events: none;
 }
 
 .vue-flow__handle.handle--ghost.valid {

--- a/src/components/GhostNode.vue
+++ b/src/components/GhostNode.vue
@@ -16,14 +16,15 @@
       <!-- <button debug>Debug</button>  -->
     </Card>
 
-    <template v-for="handle in targetHandles" :key="handle.uid" class="handle">
+    <template v-for="handle in targetHandles" :key="handle.uid">
       <Handle
         :id="getHandleId(handle)"
         :position="handlePosition(handle.side)"
+        :class="['handle', `handle--${handle.variant || 'default'}`]"
         :style="getHandleStyle(handle, targetHandles)"
-        class="port-handle"
-      />
-    </template>
+      >
+      </Handle>
+  </template>
   </div>
 </template>
 
@@ -71,6 +72,31 @@ const nodeStyle = computed(() => {
 </script>
 
 <style scoped>
+.vue-flow__handle.handle--default {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--p-text-color);
+  opacity: 1;
+}
+
+.vue-flow__handle.handle--ghost {
+  width: 25px;
+  height: 25px;
+  border-radius: 50%;
+  background: transparent;
+  border: none;
+  opacity: 0;
+  pointer-events: auto;
+}
+
+.vue-flow__handle.handle--ghost.valid {
+  background-color: rgba(34, 197, 94, 0.15);
+  border-color: #22c55e;  
+  border-style: solid;
+  opacity: 1;
+}
+
 /* Visual styling to make it look "Ghostly" */
 .ghost-card {
   --p-card-color: #1f2937;

--- a/src/components/GhostNode.vue
+++ b/src/components/GhostNode.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, watch, nextTick } from 'vue'
 
 import Card from 'primevue/card'
 
@@ -37,7 +37,7 @@ import { useVueFlow, Handle } from '@vue-flow/core'
 import { getHandleId, getHandleStyle, handlePosition } from '../utils/handles'
 
 const props = defineProps(['id', 'data'])
-const { findNode } = useVueFlow()
+const { findNode, updateNodeInternals } = useVueFlow()
 
 const ghostLabel = computed(() => {
   return `${props.data.mathRef.split(':')[1]} [${props.data.mathRef.split(':')[0]}]`
@@ -69,6 +69,14 @@ const nodeStyle = computed(() => {
     height: `${node.dimensions.height}px`,
   }
 })
+
+watch(
+  targetHandles,
+  async () => {
+    await nextTick() 
+    updateNodeInternals([props.id])
+  }
+)
 </script>
 
 <style scoped>

--- a/src/components/GhostNode.vue
+++ b/src/components/GhostNode.vue
@@ -23,7 +23,7 @@
         :class="['handle', `handle--${handle.variant || 'default'}`]"
         :style="getHandleStyle(handle, targetHandles)"
       />
-  </template>
+    </template>
   </div>
 </template>
 

--- a/src/components/GhostNode.vue
+++ b/src/components/GhostNode.vue
@@ -22,8 +22,7 @@
         :position="handlePosition(handle.side)"
         :class="['handle', `handle--${handle.variant || 'default'}`]"
         :style="getHandleStyle(handle, targetHandles)"
-      >
-      </Handle>
+      />
   </template>
   </div>
 </template>

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -132,7 +132,7 @@ import Menu from 'primevue/menu'
 import CellMLIcon from './icons/CellMLIcon.vue'
 import { useLibraryStore } from '../stores/libraryStore'
 import { useFlowHistoryStore } from '../stores/historyStore'
-import { getHandleId, getHandleStyle, handlePosition } from '../utils/handles'
+import { getHandleId, getHandleStyle, handlePosition, findMostCentralGhostHandle } from '../utils/handles'
 import { sanitiseName } from '../utils/nodes'
 import { notify } from '../utils/notify'
 import { isEditableVariableType, isEmpty } from '../utils/variables'
@@ -334,21 +334,7 @@ async function removeHandle(handleIdToRemove) {
 }
 
 const addHandle = async (handleToAdd) => {
-  const handlesOnSide = props.data.handles.filter((h) => h.side === handleToAdd.side)
-  const center = (handlesOnSide.length - 1) / 2
-
-  let mostCentralGhost = null
-  let smallestDistance = Infinity
-
-  handlesOnSide.forEach((h, index) => {
-    if (h.variant !== HANDLE_VARIANT.GHOST) return
-
-    const distance = Math.abs(index - center)
-    if (distance < smallestDistance) {
-      smallestDistance = distance
-      mostCentralGhost = h
-    }
-  })
+  const mostCentralGhost = findMostCentralGhostHandle(handleToAdd.side, props.data.handles)
 
   if (!mostCentralGhost) {
     return
@@ -426,8 +412,8 @@ function openContextMenu(event) {
 }
 
 .vue-flow__handle.handle--ghost {
-  width: 30px;
-  height: 30px;
+  width: 25px;
+  height: 25px;
   border-radius: 50%;
   background: transparent;
   border: none;

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -425,8 +425,8 @@ function openContextMenu(event) {
 }
 
 .vue-flow__handle.handle--ghost {
-  width: 40px;
-  height: 40px;
+  width: 30px;
+  height: 30px;
   border-radius: 50%;
   background: transparent;
   border: none;
@@ -441,6 +441,7 @@ function openContextMenu(event) {
   border-style: solid;
   opacity: 1;
 }
+
 .instance-name {
   min-height: 2.5rem; 
   display: flex;

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -97,7 +97,7 @@
         :id="getHandleId(handle)"
         :ref="'handle_' + handle.side + '_' + handle.uid"
         :position="handlePosition(handle.side)"
-        class="handle"
+        :class="['handle', `handle--${handle.variant || 'default'}`]"
         :style="getHandleStyle(handle, data.handles)"
         v-tooltip.bottom="{ value: handle.name, showDelay: 1000 }"
         @mouseenter="onHandleEnter(handle.uid)"
@@ -224,9 +224,11 @@ function handleSetDomainType(newType) {
 }
 
 const domainMenuRef = ref(null)
+
 function toggleDomainMenu(event) {
   domainMenuRef.value?.toggle(event)
 }
+
 const domainTypeMenuItems = [
   { label: 'Membrane', command: () => handleSetDomainType('membrane') },
   { label: 'Process', command: () => handleSetDomainType('process') },
@@ -237,9 +239,11 @@ const domainTypeMenuItems = [
 ]
 
 const portMenuRef = ref(null)
+
 function togglePortMenu(event) {
   portMenuRef.value?.toggle(event)
 }
+
 const portMenuItems = [
   { label: 'Left', command: () => addHandle({ side: 'left' }) },
   { label: 'Right', command: () => addHandle({ side: 'right' }) },
@@ -407,12 +411,31 @@ function openContextMenu(event) {
 <style lang="scss" scoped>
 @import '../assets/vueflowhandle.css';
 
-.handle {
-  width: 14px !important;
-  height: 14px !important;
-  border-radius: 50% !important; 
+.vue-flow__handle.handle--default {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--p-text-color);
+  opacity: 1;
 }
 
+.vue-flow__handle.handle--ghost {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: transparent;
+  border: none;
+  opacity: 0;
+  pointer-events: auto;
+}
+
+.vue-flow__handle.handle--ghost:hover,
+.vue-flow__handle.handle--ghost.valid {
+  background-color: rgba(34, 197, 94, 0.15);
+  border-color: #22c55e;  
+  border-style: solid;
+  opacity: 1;
+}
 .instance-name {
   min-height: 2.5rem; 
   display: flex;

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -305,7 +305,9 @@ async function removeHandle(handleIdToRemove) {
   const edgesSnapshot = connectedEdges.map((edge) => detachReactivity(edge))
 
   // Define New Handles (for Redo)
-  const newHandles = props.data.handles.filter((h) => h.uid !== handleIdToRemove)
+  const newHandles = props.data.handles.map(
+    (h) => h.uid === handleIdToRemove ? { ...h, variant: HANDLE_VARIANT.GHOST } : h
+  )
 
   // Add Composite Command to History
   historyStore.executeAndAddCommand({

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -105,7 +105,7 @@
         v-tooltip.bottom="{ value: handle.name, showDelay: 1000 }"
         @mouseenter="onHandleEnter(handle.uid)"
         @mouseleave="onHandleLeave"
-        @pointerdown="(!selected && isCornerHandle(handle, data.handles)) && handle.variant === HANDLE_VARIANT.GHOST && beginGhostActivation(props.id, handle.uid)"
+        @pointerdown="!(selected && isCornerHandle(handle, data.handles)) && handle.variant === HANDLE_VARIANT.GHOST && beginGhostActivation(props.id, handle.uid)"
       >
         <Button
           v-show="hoveredHandleUid === handle.uid && handle.variant !== HANDLE_VARIANT.GHOST"

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -105,7 +105,7 @@
         @pointerdown="handle.variant === HANDLE_VARIANT.GHOST && activateHandle(props.id, handle.uid)"
       >
         <Button
-          v-show="hoveredHandleUid === handle.uid"
+          v-show="hoveredHandleUid === handle.uid && handle.variant !== HANDLE_VARIANT.GHOST"
           :class="['delete-handle-popover-btn', 'popover-' + handle.side]"
           icon="pi pi-trash"
           severity="danger"

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -289,7 +289,7 @@ function onHandleLeave() {
 async function removeHandle(handleIdToRemove) {
   const oldHandles = detachReactivity(props.data.handles)
 
-  const handle = oldHandles.find((p) => p.uid === handleIdToRemove)
+  const handle = oldHandles.find((h) => h.uid === handleIdToRemove)
   if (!handle) return
 
   const handleId = getHandleId(handle)
@@ -334,26 +334,8 @@ async function removeHandle(handleIdToRemove) {
 }
 
 const addHandle = async (handleToAdd) => {
-  const oldHandles = [...props.data.handles]
-
-  const newHandle = {
-    ...handleToAdd,
-    uid: crypto.randomUUID(),
-  }
-
-  const newHandles = [...props.data.handles, newHandle]
-
-  await applyHandles(newHandles)
-
-  historyStore.addCommand({
-    type: 'add-handle',
-    undo: async () => {
-      applyHandles(oldHandles)
-    },
-    redo: async () => {
-      applyHandles(newHandles)
-    },
-  })
+  const handle = props.data.handles.find((h) => h.side === handleToAdd.side && h.variant === HANDLE_VARIANT.GHOST)
+  activateHandle(props.id, handle.uid)
 }
 
 const isEditing = ref(false)

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -97,12 +97,15 @@
         :id="getHandleId(handle)"
         :ref="'handle_' + handle.side + '_' + handle.uid"
         :position="handlePosition(handle.side)"
-        :class="['handle', `handle--${handle.variant || 'default'}`]"
+        :class="['handle',
+        `handle--${handle.variant|| 'default'}`,
+        { 'handle--inert': handle.variant === HANDLE_VARIANT.GHOST && selected },
+        ]"
         :style="getHandleStyle(handle, data.handles)"
         v-tooltip.bottom="{ value: handle.name, showDelay: 1000 }"
         @mouseenter="onHandleEnter(handle.uid)"
         @mouseleave="onHandleLeave"
-        @pointerdown="handle.variant === HANDLE_VARIANT.GHOST && beginGhostActivation(props.id, handle.uid)"
+        @pointerdown="handle.variant === !selected && HANDLE_VARIANT.GHOST && beginGhostActivation(props.id, handle.uid)"
       >
         <Button
           v-show="hoveredHandleUid === handle.uid && handle.variant !== HANDLE_VARIANT.GHOST"
@@ -427,6 +430,10 @@ function openContextMenu(event) {
   border-color: #22c55e;  
   border-style: solid;
   opacity: 1;
+}
+
+.vue-flow__handle.handle--ghost.handle--inert {
+  pointer-events: none;
 }
 
 .instance-name {

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -334,8 +334,27 @@ async function removeHandle(handleIdToRemove) {
 }
 
 const addHandle = async (handleToAdd) => {
-  const handle = props.data.handles.find((h) => h.side === handleToAdd.side && h.variant === HANDLE_VARIANT.GHOST)
-  activateHandle(props.id, handle.uid)
+  const handlesOnSide = props.data.handles.filter((h) => h.side === handleToAdd.side)
+  const center = (handlesOnSide.length - 1) / 2
+
+  let mostCentralGhost = null
+  let smallestDistance = Infinity
+
+  handlesOnSide.forEach((h, index) => {
+    if (h.variant !== HANDLE_VARIANT.GHOST) return
+
+    const distance = Math.abs(index - center)
+    if (distance < smallestDistance) {
+      smallestDistance = distance
+      mostCentralGhost = h
+    }
+  })
+
+  if (!mostCentralGhost) {
+    return
+  }
+
+  await activateHandle(props.id, mostCentralGhost.uid)
 }
 
 const isEditing = ref(false)

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -102,7 +102,7 @@
         v-tooltip.bottom="{ value: handle.name, showDelay: 1000 }"
         @mouseenter="onHandleEnter(handle.uid)"
         @mouseleave="onHandleLeave"
-        @pointerdown="handle.variant === HANDLE_VARIANT.GHOST && activateHandle(props.id, handle.uid)"
+        @pointerdown="handle.variant === HANDLE_VARIANT.GHOST && beginGhostActivation(props.id, handle.uid)"
       >
         <Button
           v-show="hoveredHandleUid === handle.uid && handle.variant !== HANDLE_VARIANT.GHOST"
@@ -142,7 +142,7 @@ import { TARGET_HANDLE_TYPE, SOURCE_HANDLE_TYPE, HANDLE_VARIANT } from '../utils
 import { useHandleActivation } from '../composables/useHandleActivation'
 
 const { addEdges, edges, removeEdges, updateNodeData, updateNodeInternals, nodes } = useVueFlow()
-const { activateHandle } = useHandleActivation()
+const { beginGhostActivation } = useHandleActivation()
 const historyStore = useFlowHistoryStore()
 const libraryStore = useLibraryStore()
 

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -105,7 +105,7 @@
         v-tooltip.bottom="{ value: handle.name, showDelay: 1000 }"
         @mouseenter="onHandleEnter(handle.uid)"
         @mouseleave="onHandleLeave"
-        @pointerdown="handle.variant === !selected && HANDLE_VARIANT.GHOST && beginGhostActivation(props.id, handle.uid)"
+        @pointerdown="!selected && handle.variant === HANDLE_VARIANT.GHOST && beginGhostActivation(props.id, handle.uid)"
       >
         <Button
           v-show="hoveredHandleUid === handle.uid && handle.variant !== HANDLE_VARIANT.GHOST"

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -142,7 +142,7 @@ import { TARGET_HANDLE_TYPE, SOURCE_HANDLE_TYPE, HANDLE_VARIANT } from '../utils
 import { useHandleActivation } from '../composables/useHandleActivation'
 
 const { addEdges, edges, removeEdges, updateNodeData, updateNodeInternals, nodes } = useVueFlow()
-const { beginGhostActivation } = useHandleActivation()
+const { beginGhostActivation, activateHandle } = useHandleActivation()
 const historyStore = useFlowHistoryStore()
 const libraryStore = useLibraryStore()
 

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -99,13 +99,13 @@
         :position="handlePosition(handle.side)"
         :class="['handle',
         `handle--${handle.variant|| 'default'}`,
-        { 'handle--inert': handle.variant === HANDLE_VARIANT.GHOST && selected },
+        { 'handle--inert': handle.variant === HANDLE_VARIANT.GHOST && selected && isCornerHandle(handle, data.handles)},
         ]"
         :style="getHandleStyle(handle, data.handles)"
         v-tooltip.bottom="{ value: handle.name, showDelay: 1000 }"
         @mouseenter="onHandleEnter(handle.uid)"
         @mouseleave="onHandleLeave"
-        @pointerdown="!selected && handle.variant === HANDLE_VARIANT.GHOST && beginGhostActivation(props.id, handle.uid)"
+        @pointerdown="(!selected && isCornerHandle(handle, data.handles)) && handle.variant === HANDLE_VARIANT.GHOST && beginGhostActivation(props.id, handle.uid)"
       >
         <Button
           v-show="hoveredHandleUid === handle.uid && handle.variant !== HANDLE_VARIANT.GHOST"
@@ -135,7 +135,7 @@ import Menu from 'primevue/menu'
 import CellMLIcon from './icons/CellMLIcon.vue'
 import { useLibraryStore } from '../stores/libraryStore'
 import { useFlowHistoryStore } from '../stores/historyStore'
-import { getHandleId, getHandleStyle, handlePosition, findMostCentralGhostHandle } from '../utils/handles'
+import { getHandleId, getHandleStyle, handlePosition, findMostCentralGhostHandle, isCornerHandle } from '../utils/handles'
 import { sanitiseName } from '../utils/nodes'
 import { notify } from '../utils/notify'
 import { isEditableVariableType, isEmpty } from '../utils/variables'

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -139,10 +139,10 @@ import { isEditableVariableType, isEmpty } from '../utils/variables'
 import '../assets/vueflownode.css'
 import { detachReactivity } from '../utils/reactivity'
 import { TARGET_HANDLE_TYPE, SOURCE_HANDLE_TYPE, HANDLE_VARIANT } from '../utils/constants'
-import { useHandleActivation } from '../composables/useHandleActivation'
+import { useHandleManagement } from '../composables/useHandleManagement'
 
 const { addEdges, edges, removeEdges, updateNodeData, updateNodeInternals, nodes } = useVueFlow()
-const { beginGhostActivation, activateHandle } = useHandleActivation()
+const { beginGhostActivation, activateHandle } = useHandleManagement()
 const historyStore = useFlowHistoryStore()
 const libraryStore = useLibraryStore()
 

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -102,6 +102,7 @@
         v-tooltip.bottom="{ value: handle.name, showDelay: 1000 }"
         @mouseenter="onHandleEnter(handle.uid)"
         @mouseleave="onHandleLeave"
+        @pointerdown="handle.variant === HANDLE_VARIANT.GHOST && activateHandle(props.id, handle.uid)"
       >
         <Button
           v-show="hoveredHandleUid === handle.uid"
@@ -137,9 +138,11 @@ import { notify } from '../utils/notify'
 import { isEditableVariableType, isEmpty } from '../utils/variables'
 import '../assets/vueflownode.css'
 import { detachReactivity } from '../utils/reactivity'
-import { TARGET_HANDLE_TYPE, SOURCE_HANDLE_TYPE } from '../utils/constants'
+import { TARGET_HANDLE_TYPE, SOURCE_HANDLE_TYPE, HANDLE_VARIANT } from '../utils/constants'
+import { useHandleActivation } from '../composables/useHandleActivation'
 
 const { addEdges, edges, removeEdges, updateNodeData, updateNodeInternals, nodes } = useVueFlow()
+const { activateHandle } = useHandleActivation()
 const historyStore = useFlowHistoryStore()
 const libraryStore = useLibraryStore()
 

--- a/src/components/MacroBuilderDialog.vue
+++ b/src/components/MacroBuilderDialog.vue
@@ -6,19 +6,26 @@
     :modal="true"
     :draggable="false"
     :closable="true"
-    :dismissableMask="true"
+    :dismissableMask="isFlowReady"
     :appendTo="'body'"
     :style="{ width: '95vw', maxWidth: '95vw', height: '90vh' }"
+    @show="onDialogShow"
     @hide="closeDialog"
   >
     <div class="macro-dialog-body">
       <ResizableLibraryPanel title="Module Library" :initial-width="200" :min-width="150" :max-width="400">
         <LibraryArea />
       </ResizableLibraryPanel>
-
       <main class="workbench-macro">
-        <div class="dnd-flow" @drop="onDrop" @dragover.prevent>
+        <div class="dnd-flow" @drop="onDrop" @dragover.prevent ref="canvasEl">
+          <Transition name="fade">
+            <div v-if="!isFlowReady" class="flow-loading-overlay">
+              <i class="pi pi-spin pi-spinner loading-icon" />
+              <span>Initialising macro builder...</span>
+            </div>
+          </Transition>
           <VueFlow
+            v-if="isFlowReady"
             :id="FLOW_IDS.MACRO"
             @dragleave="onDragLeave"
             @nodes-change="onNodeChange"
@@ -26,6 +33,7 @@
             :default-edge-options="macroEdgeOptions"
             :connection-line-options="macroEdgeOptions"
             :nodes="nodes"
+            :edges="edges"
             :delete-key-code="['Backspace', 'Delete']"
           >
             <template #node-instanceNode="props">
@@ -59,14 +67,17 @@
   </Dialog>
 
   <GhostSetupModal v-if="isGhostSetupOpen" @confirm="finalizeGhostNode" @cancel="cancelGhostNode" />
+
+  <ConfirmDialog />
 </template>
 
 <script setup>
-import { computed, ref, watch } from 'vue'
+import { computed, ref, watch, nextTick } from 'vue'
 import { VueFlow, useVueFlow } from '@vue-flow/core'
 import Button from 'primevue/button'
 import Dialog from 'primevue/dialog'
 import InputNumber from 'primevue/inputnumber'
+import ConfirmDialog from 'primevue/confirmdialog'
 
 import WorkbenchArea from './WorkbenchArea.vue'
 import LibraryArea from './LibraryArea.vue'
@@ -78,6 +89,7 @@ import { useLibraryStore } from '../stores/libraryStore'
 import { useGtm } from '../composables/useGtm'
 import useDragAndDrop from '../composables/useDnD'
 import { useHandleManagement } from '../composables/useHandleManagement'
+import { useConfirmDialog } from '../composables/useConfirmDialog'
 import {
   edgeLineOptions,
   FLOW_IDS,
@@ -90,11 +102,16 @@ import {
   markerEnd,
 } from '../utils/constants'
 import { detachReactivity } from '../utils/reactivity'
-import { getHandleUidFromHandleId } from '../utils/handles.js'
+import { getHandleUidFromHandleId } from '../utils/handles'
+import { useConfirm } from 'primevue'
 
-const { addEdges, edges, findNode, nodes, onConnect, onConnectEnd, onDragLeave, onNodeChange, onEdgeChange, removeNodes } =
+const { addEdges, removeEdges, edges,  onEdgeChange,
+  findNode, nodes, onNodeChange, removeNodes,
+  onConnect, onConnectEnd, 
+  onDragLeave, updateNodeInternals } =
   useVueFlow(FLOW_IDS.MACRO)
 
+const confirm = useConfirmDialog()
 const previousNodes = new Set()
 const { onDrop, isGhostSetupOpen, pendingGhostNodeId } = useDragAndDrop(previousNodes)
 const { trackEvent } = useGtm()
@@ -114,6 +131,8 @@ const emit = defineEmits(['update:modelValue', 'generate', 'edit-node'])
 
 const multiplier = ref(1)
 const nodeRefs = ref({})
+const isFlowReady = ref(false)
+const canvasEl = ref(null)
 
 const visible = computed({
   get: () => props.modelValue,
@@ -128,8 +147,9 @@ const macroEdgeOptions = {
   },
 }
 
-onConnect((connection) => {
+const suppressedEdgeIds = new Set()
 
+onConnect(async (connection) => {
   confirmActivation()
   if (connection.sourceHandle) {
     activateHandle(connection.source, getHandleUidFromHandleId(connection.sourceHandle))
@@ -144,10 +164,68 @@ onConnect((connection) => {
     }
   }
 
+  const duplicate = edges.value.find(
+    (e) => e.source === connection.source && e.target === connection.target
+  )
+
+  const duplicateSnapshot = duplicate ? detachReactivity(duplicate) : null
+
+  const sourceHandleUid = connection.sourceHandle
+    ? getHandleUidFromHandleId(connection.sourceHandle)
+    : null
+  const targetHandleUid = connection.targetHandle
+    ? getHandleUidFromHandleId(connection.targetHandle)
+    : null
+
+  confirmActivation()
+
+  if (sourceHandleUid) {
+    activateHandle(connection.source, sourceHandleUid, { trackHistory: false })
+  }
+  if (targetHandleUid) {
+    activateHandle(connection.target, targetHandleUid, { trackHistory: false })
+  }
+
+  if (duplicate) {
+    const pendingEdge = {
+      ...connection,
+      id: `pending--${connection.source}--${connection.target}`,
+      style: { strokeDasharray: '8 8', opacity: 0.4 }, 
+    }
+
+    // Prevents addition to history store.
+    suppressedEdgeIds.add(pendingEdge.id)
+    addEdges(pendingEdge)
+
+    const shouldReplace = await confirm({
+      header: 'Connection already exists',
+      message:
+        'A connection already exists between these instances. Do you wish to replace it?\n\n' +
+        'If you select Cancel, the new connection will be discarded and the existing connection will remain.',
+      severity: 'warning',
+      acceptLabel: 'Replace',
+      rejectLabel: 'Cancel',
+    })
+
+    removeEdges(pendingEdge.id)
+    suppressedEdgeIds.delete(pendingEdge.id)
+
+    if (!shouldReplace) {
+      if (sourceHandleUid) revertHandleIfUnused(connection.source, sourceHandleUid, { trackHistory: false })
+      if (targetHandleUid) revertHandleIfUnused(connection.target, targetHandleUid, { trackHistory: false })
+      return
+    }
+
+    suppressedEdgeIds.add(duplicate.id)
+    removeEdges(duplicate.id)
+    revertHandlesForEdge(duplicateSnapshot)
+  }
+
   // Match what we specify in connectionLineOptions.
   const newEdge = {
     ...connection,
     ...macroEdgeOptions,
+    id: `macro-${connection.source}-${connection.target}`
   }
 
   addEdges(newEdge)
@@ -164,6 +242,57 @@ function onOpenEditDialog(eventPayload) {
   })
 }
 
+function waitUntilStable(el, maxTimeout = 500) {
+  return new Promise((resolve) => {
+    if (!el) return resolve()
+
+    let lastRect = ''
+    let stableFrames = 0
+    let rafId = null
+    let timerId = null
+
+    const cleanup = () => {
+      if (rafId) cancelAnimationFrame(rafId)
+      if (timerId) clearTimeout(timerId)
+    }
+
+    const check = () => {
+      const rect = el.getBoundingClientRect()
+      const currentRect = `${rect.width},${rect.height},${rect.top},${rect.left}`
+
+      if (rect.width > 0 && rect.height > 0 && currentRect === lastRect) {
+        stableFrames++
+        if (stableFrames >= 3) {
+          cleanup()
+          return resolve()
+        }
+      } else {
+        stableFrames = 0
+        lastRect = currentRect
+      }
+
+      rafId = requestAnimationFrame(check)
+    }
+
+    timerId = setTimeout(() => {
+      cleanup()
+      resolve()
+    }, maxTimeout)
+
+    rafId = requestAnimationFrame(check)
+  })
+}
+
+async function onDialogShow() {
+  isFlowReady.value = false
+  await nextTick()
+  await waitUntilStable(canvasEl.value, 400)
+  isFlowReady.value = true
+  await nextTick()
+  const nodeIds = nodes.value.map(n => n.id)
+  updateNodeInternals(nodeIds)
+}
+
 watch(
   () => props.modelValue,
   (newVal) => {
@@ -174,6 +303,7 @@ watch(
 )
 
 function closeDialog() {
+  isFlowReady.value = false
   visible.value = false
 }
 
@@ -224,7 +354,6 @@ const finalizeGhostNode = (selectedTargetNodeId) => {
 
 // --- Handle Modal Cancellation ---
 const cancelGhostNode = () => {
-  // If user cancels, we should remove the empty ghost node they just dropped
   if (pendingGhostNodeId.value) {
     removeNodes([pendingGhostNodeId.value])
   }
@@ -235,6 +364,38 @@ const cancelGhostNode = () => {
 </script>
 
 <style scoped>
+.flow-loading-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  background: color-mix(in srgb, var(--p-content-background, #18181b) 85%, transparent);
+  backdrop-filter: blur(4px);
+  z-index: 20;
+  color: var(--p-text-muted-color, #909399);
+  font-size: 20px;
+  font-weight: 500;
+}
+
+.loading-icon {
+  font-size: 22px;
+  color: var(--p-primary-color, #409eff);
+}
+
+/* ── Smooth Fade Transitions ── */
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.25s ease-in-out;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
 .macro-dialog-body {
   display: flex;
   flex: 1 1 auto;

--- a/src/components/MacroBuilderDialog.vue
+++ b/src/components/MacroBuilderDialog.vue
@@ -85,6 +85,7 @@ import {
   GHOST_MODULE_DEFINITION,
   GHOST_MODULE_FILENAME,
   GHOST_MODULE_REF,
+  GHOST_NODE_TYPE,
   MACRO_BUILDER_ARROW,
   markerEnd,
 } from '../utils/constants'
@@ -131,11 +132,17 @@ onConnect((connection) => {
 
   confirmActivation()
   if (connection.sourceHandle) {
-    activateHandle(connection.target, getHandleUidFromHandleId(connection.source))
+    activateHandle(connection.source, getHandleUidFromHandleId(connection.sourceHandle))
   }
 
-  if (connection.targetHandle) {
-    activateHandle(connection.source, getHandleUidFromHandleId(connection.targetHandle))
+  if (connection.targetHandle) { 
+    const targetNode = findNode(connection.target)
+    console.log(targetNode)
+    if (targetNode.type === GHOST_NODE_TYPE) {
+      activateHandle(connection.source, getHandleUidFromHandleId(connection.targetHandle))
+    } else {
+      activateHandle(connection.target, getHandleUidFromHandleId(connection.targetHandle))
+    }
   }
 
   // Match what we specify in connectionLineOptions.

--- a/src/components/MacroBuilderDialog.vue
+++ b/src/components/MacroBuilderDialog.vue
@@ -77,6 +77,7 @@ import GhostSetupModal from './GhostSetupDialog.vue'
 import { useLibraryStore } from '../stores/libraryStore'
 import { useGtm } from '../composables/useGtm'
 import useDragAndDrop from '../composables/useDnD'
+import { useHandleActivation } from '../composables/useHandleActivation'
 import {
   edgeLineOptions,
   FLOW_IDS,
@@ -88,13 +89,16 @@ import {
   markerEnd,
 } from '../utils/constants'
 import { detachReactivity } from '../utils/reactivity'
+import { getHandleUidFromHandleId } from '../utils/handles.js'
 
-const { addEdges, edges, findNode, nodes, onConnect, onDragLeave, onNodeChange, onEdgeChange, removeNodes } =
+const { addEdges, edges, findNode, nodes, onConnect, onConnectEnd, onDragLeave, onNodeChange, onEdgeChange, removeNodes } =
   useVueFlow(FLOW_IDS.MACRO)
 
 const previousNodes = new Set()
 const { onDrop, isGhostSetupOpen, pendingGhostNodeId } = useDragAndDrop(previousNodes)
 const { trackEvent } = useGtm()
+
+const { revertPendingGhostIfUnused, confirmActivation, activateHandle } = useHandleActivation()
 
 const libraryStore = useLibraryStore()
 
@@ -124,6 +128,16 @@ const macroEdgeOptions = {
 }
 
 onConnect((connection) => {
+
+  confirmActivation()
+  if (connection.sourceHandle) {
+    activateHandle(connection.target, getHandleUidFromHandleId(connection.source))
+  }
+
+  if (connection.targetHandle) {
+    activateHandle(connection.source, getHandleUidFromHandleId(connection.targetHandle))
+  }
+
   // Match what we specify in connectionLineOptions.
   const newEdge = {
     ...connection,
@@ -131,6 +145,10 @@ onConnect((connection) => {
   }
 
   addEdges(newEdge)
+})
+
+onConnectEnd(() => {
+  revertPendingGhostIfUnused()
 })
 
 function onOpenEditDialog(eventPayload) {

--- a/src/components/MacroBuilderDialog.vue
+++ b/src/components/MacroBuilderDialog.vue
@@ -77,7 +77,7 @@ import GhostSetupModal from './GhostSetupDialog.vue'
 import { useLibraryStore } from '../stores/libraryStore'
 import { useGtm } from '../composables/useGtm'
 import useDragAndDrop from '../composables/useDnD'
-import { useHandleActivation } from '../composables/useHandleActivation'
+import { useHandleManagement } from '../composables/useHandleManagement'
 import {
   edgeLineOptions,
   FLOW_IDS,
@@ -99,7 +99,7 @@ const previousNodes = new Set()
 const { onDrop, isGhostSetupOpen, pendingGhostNodeId } = useDragAndDrop(previousNodes)
 const { trackEvent } = useGtm()
 
-const { revertPendingGhostIfUnused, confirmActivation, activateHandle } = useHandleActivation()
+const { revertPendingGhostIfUnused, confirmActivation, activateHandle } = useHandleManagement()
 
 const libraryStore = useLibraryStore()
 

--- a/src/components/MacroBuilderDialog.vue
+++ b/src/components/MacroBuilderDialog.vue
@@ -137,7 +137,6 @@ onConnect((connection) => {
 
   if (connection.targetHandle) { 
     const targetNode = findNode(connection.target)
-    console.log(targetNode)
     if (targetNode.type === GHOST_NODE_TYPE) {
       activateHandle(connection.source, getHandleUidFromHandleId(connection.targetHandle))
     } else {

--- a/src/composables/useDnD.js
+++ b/src/composables/useDnD.js
@@ -1,6 +1,6 @@
 import { useVueFlow } from '@vue-flow/core'
 import { ref, shallowRef, watch } from 'vue'
-import { GHOST_MODULE_FILENAME, GHOST_NODE_TYPE, MAIN_NODE_TYPE } from '../utils/constants'
+import { GHOST_MODULE_FILENAME, GHOST_NODE_TYPE, MAIN_NODE_TYPE, NUM_GHOST_HANDLES } from '../utils/constants'
 import { getId as getNextNodeId } from '../utils/nodes'
 import { generateUniqueInstanceName, findAnyNode } from '../utils/nodes'
 import { buildInstance } from '../services/import/buildWorkflow'
@@ -88,8 +88,8 @@ export default function useDragAndDrop(pendingHistoryNodes) {
     const instanceName = moduleData.moduleRef.includes(":") ? moduleData.moduleRef.split(":")[0] : moduleData.moduleRef
     const finalName = generateUniqueInstanceName(instanceName, existingNames)
 
-    const allHandles = [...handles, ...buildGhostHandles(16)]
-    
+    const allHandles = [...handles, ...buildGhostHandles(NUM_GHOST_HANDLES)]
+
     const componentFile = moduleData.mathRef.split(":")[0]
     const nodeType = componentFile === GHOST_MODULE_FILENAME ? GHOST_NODE_TYPE : MAIN_NODE_TYPE
     

--- a/src/composables/useDnD.js
+++ b/src/composables/useDnD.js
@@ -1,6 +1,12 @@
 import { useVueFlow } from '@vue-flow/core'
 import { ref, shallowRef, watch } from 'vue'
-import { GHOST_MODULE_FILENAME, GHOST_NODE_TYPE, MAIN_NODE_TYPE, NUM_GHOST_HANDLES } from '../utils/constants'
+import {
+  GHOST_MODULE_FILENAME,
+  GHOST_NODE_TYPE,
+  MAIN_NODE_TYPE,
+  NUM_GHOST_HANDLES_SIDES,
+  NUM_GHOST_HANDLES_TOP_BOT
+} from '../utils/constants'
 import { getId as getNextNodeId } from '../utils/nodes'
 import { generateUniqueInstanceName, findAnyNode } from '../utils/nodes'
 import { buildInstance } from '../services/import/buildWorkflow'
@@ -88,7 +94,7 @@ export default function useDragAndDrop(pendingHistoryNodes) {
     const instanceName = moduleData.moduleRef.includes(":") ? moduleData.moduleRef.split(":")[0] : moduleData.moduleRef
     const finalName = generateUniqueInstanceName(instanceName, existingNames)
 
-    const allHandles = [...handles, ...buildGhostHandles(NUM_GHOST_HANDLES)]
+    const allHandles = [...handles, ...buildGhostHandles(NUM_GHOST_HANDLES_TOP_BOT, NUM_GHOST_HANDLES_SIDES)]
 
     const componentFile = moduleData.mathRef.split(":")[0]
     const nodeType = componentFile === GHOST_MODULE_FILENAME ? GHOST_NODE_TYPE : MAIN_NODE_TYPE

--- a/src/composables/useDnD.js
+++ b/src/composables/useDnD.js
@@ -4,6 +4,7 @@ import { GHOST_MODULE_FILENAME, GHOST_NODE_TYPE, MAIN_NODE_TYPE } from '../utils
 import { getId as getNextNodeId } from '../utils/nodes'
 import { generateUniqueInstanceName, findAnyNode } from '../utils/nodes'
 import { buildInstance } from '../services/import/buildWorkflow'
+import { buildGhostHandles } from '../utils/handles'
 
 /**
  * In a real world scenario you'd want to avoid creating refs in a global scope like this as they might not be cleaned up properly.
@@ -87,10 +88,12 @@ export default function useDragAndDrop(pendingHistoryNodes) {
     const instanceName = moduleData.moduleRef.includes(":") ? moduleData.moduleRef.split(":")[0] : moduleData.moduleRef
     const finalName = generateUniqueInstanceName(instanceName, existingNames)
 
+    const allHandles = [...handles, ...buildGhostHandles(16)]
+    
     const componentFile = moduleData.mathRef.split(":")[0]
     const nodeType = componentFile === GHOST_MODULE_FILENAME ? GHOST_NODE_TYPE : MAIN_NODE_TYPE
     
-    const newNode = buildInstance(nodeId, finalName, nodeType, moduleData, handles, position)
+    const newNode = buildInstance(nodeId, finalName, nodeType, moduleData, allHandles, position)
 
     /**
      * Align node position after drop, so it's centered to the mouse.

--- a/src/composables/useHandleActivation.js
+++ b/src/composables/useHandleActivation.js
@@ -1,23 +1,26 @@
-import { nextTick } from 'vue'
+import { nextTick, ref } from 'vue'
 import { useVueFlow } from '@vue-flow/core'
 import { useFlowHistoryStore } from '../stores/historyStore'
 import { HANDLE_VARIANT } from '../utils/constants'
+import { getHandleId } from '../utils/handles'
 import { detachReactivity } from '../utils/reactivity'
 
+const pendingGhostRevert = ref(null)
+
 export function useHandleActivation() {
-  const { getNodes, updateNodeData, updateNodeInternals } = useVueFlow()
+  const { getNodes, updateNodeData, updateNodeInternals, edges } = useVueFlow()
   const historyStore = useFlowHistoryStore()
 
-  async function activateHandle(nodeId, handleUid) {
+  async function setHandleVariant(nodeId, handleUid, variant) {
     const node = getNodes.value.find((n) => n.id === nodeId)
     if (!node) return
 
     const handle = node.data.handles.find((h) => h.uid === handleUid)
-    if (!handle || handle.variant !== HANDLE_VARIANT.GHOST) return
+    if (!handle || handle.variant === variant) return
 
     const oldHandles = detachReactivity(node.data.handles)
     const newHandles = node.data.handles.map((h) =>
-      h.uid === handleUid ? { ...h, variant: HANDLE_VARIANT.DEFAULT } : h
+      h.uid === handleUid ? { ...h, variant } : h
     )
 
     const apply = async (handles) => {
@@ -29,11 +32,51 @@ export function useHandleActivation() {
     await apply(newHandles)
 
     historyStore.addCommand({
-      type: 'activate-ghost-handle',
+      type: `set-handle-variant-${variant}`,
       undo: () => apply(oldHandles),
       redo: () => apply(newHandles),
     })
   }
 
-  return { activateHandle }
+  async function activateHandle(nodeId, handleUid) {
+    await setHandleVariant(nodeId, handleUid, HANDLE_VARIANT.DEFAULT)
+  }
+
+  function beginGhostActivation(nodeId, handleUid) {
+    pendingGhostRevert.value = { nodeId, handleUid }
+    activateHandle(nodeId, handleUid)
+  }
+
+  function confirmActivation() {
+    pendingGhostRevert.value = null
+  }
+
+  async function revertPendingGhostIfUnused() {
+    if (!pendingGhostRevert.value) return
+
+    const { nodeId, handleUid } = pendingGhostRevert.value
+    pendingGhostRevert.value = null
+
+    const node = getNodes.value.find((n) => n.id === nodeId)
+    const handle = node?.data.handles.find((h) => h.uid === handleUid)
+    if (!handle) return
+
+    const handleId = getHandleId(handle)
+    const hasEdge = edges.value.some(
+      (edge) =>
+        (edge.source === nodeId && edge.sourceHandle === handleId) ||
+        (edge.target === nodeId && edge.targetHandle === handleId)
+    )
+
+    if (!hasEdge) {
+      await setHandleVariant(nodeId, handleUid, HANDLE_VARIANT.GHOST)
+    }
+  }
+
+  return {
+    activateHandle,
+    beginGhostActivation,
+    confirmActivation,
+    revertPendingGhostIfUnused,
+  }
 }

--- a/src/composables/useHandleActivation.js
+++ b/src/composables/useHandleActivation.js
@@ -2,7 +2,7 @@ import { nextTick, ref } from 'vue'
 import { useVueFlow } from '@vue-flow/core'
 import { useFlowHistoryStore } from '../stores/historyStore'
 import { HANDLE_VARIANT } from '../utils/constants'
-import { getHandleId } from '../utils/handles'
+import { getHandleId, getHandleUidFromHandleId } from '../utils/handles'
 import { detachReactivity } from '../utils/reactivity'
 
 const pendingGhostRevert = ref(null)
@@ -51,12 +51,14 @@ export function useHandleActivation() {
     pendingGhostRevert.value = null
   }
 
-  async function revertPendingGhostIfUnused() {
-    if (!pendingGhostRevert.value) return
-
-    const { nodeId, handleUid } = pendingGhostRevert.value
-    pendingGhostRevert.value = null
-
+  /**
+   * Reverts a single handle to the ghost variant, but only if no remaining
+   * edge still terminates on it. `excludeEdgeIds` lets callers check this
+   * *before* the edge(s) being removed have actually left `edges.value`
+   * (e.g. inside onEdgeChange, ahead of applyEdgeChanges), so the check
+   * doesn't see its own soon-to-be-removed edge as "still in use".
+   */
+  async function revertHandleIfUnused(nodeId, handleUid, { excludeEdgeIds = [] } = {}) {
     const node = getNodes.value.find((n) => n.id === nodeId)
     const handle = node?.data.handles.find((h) => h.uid === handleUid)
     if (!handle) return
@@ -64,12 +66,50 @@ export function useHandleActivation() {
     const handleId = getHandleId(handle)
     const hasEdge = edges.value.some(
       (edge) =>
-        (edge.source === nodeId && edge.sourceHandle === handleId) ||
-        (edge.target === nodeId && edge.targetHandle === handleId)
+        !excludeEdgeIds.includes(edge.id) &&
+        ((edge.source === nodeId && edge.sourceHandle === handleId) ||
+          (edge.target === nodeId && edge.targetHandle === handleId))
     )
 
     if (!hasEdge) {
       await setHandleVariant(nodeId, handleUid, HANDLE_VARIANT.GHOST)
+    }
+  }
+
+  async function revertPendingGhostIfUnused() {
+    if (!pendingGhostRevert.value) return
+
+    const { nodeId, handleUid } = pendingGhostRevert.value
+    pendingGhostRevert.value = null
+
+    await revertHandleIfUnused(nodeId, handleUid)
+  }
+
+  /**
+   * Reverts both ends of a removed edge to ghost (each only if unused
+   * elsewhere). Pass the edge's own id(s) in excludeEdgeIds when calling
+   * this ahead of the edge actually being removed from edges.value.
+   */
+  async function revertHandlesForEdge(edge, excludeEdgeIds = [edge.id]) {
+    if (edge.sourceHandle) {
+      await revertHandleIfUnused(edge.source, getHandleUidFromHandleId(edge.sourceHandle), {
+        excludeEdgeIds,
+      })
+    }
+    if (edge.targetHandle) {
+      await revertHandleIfUnused(edge.target, getHandleUidFromHandleId(edge.targetHandle), {
+        excludeEdgeIds,
+      })
+    }
+  }
+
+  /** Re-activates both ends of a restored edge, e.g. on undo of a removal. */
+  async function reactivateEdgeHandles(edge) {
+    if (edge.sourceHandle) {
+      await activateHandle(edge.source, getHandleUidFromHandleId(edge.sourceHandle))
+    }
+    if (edge.targetHandle) {
+      await activateHandle(edge.target, getHandleUidFromHandleId(edge.targetHandle))
     }
   }
 
@@ -78,5 +118,8 @@ export function useHandleActivation() {
     beginGhostActivation,
     confirmActivation,
     revertPendingGhostIfUnused,
+    revertHandleIfUnused,
+    revertHandlesForEdge,
+    reactivateEdgeHandles,
   }
 }

--- a/src/composables/useHandleActivation.js
+++ b/src/composables/useHandleActivation.js
@@ -1,0 +1,39 @@
+import { nextTick } from 'vue'
+import { useVueFlow } from '@vue-flow/core'
+import { useFlowHistoryStore } from '../stores/historyStore'
+import { HANDLE_VARIANT } from '../utils/constants'
+import { detachReactivity } from '../utils/reactivity'
+
+export function useHandleActivation() {
+  const { getNodes, updateNodeData, updateNodeInternals } = useVueFlow()
+  const historyStore = useFlowHistoryStore()
+
+  async function activateHandle(nodeId, handleUid) {
+    const node = getNodes.value.find((n) => n.id === nodeId)
+    if (!node) return
+
+    const handle = node.data.handles.find((h) => h.uid === handleUid)
+    if (!handle || handle.variant !== HANDLE_VARIANT.GHOST) return
+
+    const oldHandles = detachReactivity(node.data.handles)
+    const newHandles = node.data.handles.map((h) =>
+      h.uid === handleUid ? { ...h, variant: HANDLE_VARIANT.DEFAULT } : h
+    )
+
+    const apply = async (handles) => {
+      updateNodeData(nodeId, { handles })
+      await nextTick()
+      updateNodeInternals(nodeId)
+    }
+
+    await apply(newHandles)
+
+    historyStore.addCommand({
+      type: 'activate-ghost-handle',
+      undo: () => apply(oldHandles),
+      redo: () => apply(newHandles),
+    })
+  }
+
+  return { activateHandle }
+}

--- a/src/composables/useHandleManagement.js
+++ b/src/composables/useHandleManagement.js
@@ -7,11 +7,11 @@ import { detachReactivity } from '../utils/reactivity'
 
 const pendingGhostRevert = ref(null)
 
-export function useHandleActivation() {
+export function useHandleManagement() {
   const { getNodes, updateNodeData, updateNodeInternals, edges } = useVueFlow()
   const historyStore = useFlowHistoryStore()
 
-  async function setHandleVariant(nodeId, handleUid, variant) {
+  async function setHandleVariant(nodeId, handleUid, variant, { trackHistory = true } = {}) {
     const node = getNodes.value.find((n) => n.id === nodeId)
     if (!node) return
 
@@ -31,20 +31,25 @@ export function useHandleActivation() {
 
     await apply(newHandles)
 
-    historyStore.addCommand({
-      type: `set-handle-variant-${variant}`,
-      undo: () => apply(oldHandles),
-      redo: () => apply(newHandles),
-    })
+    // Skip history for: 
+    // (a) provisional preview changes the caller has explicitly opted out of 
+    // (b) changes happening as a side effect of an undo/redo replay 
+    if (trackHistory && !historyStore.isUndoRedoing) {
+      historyStore.addCommand({
+        type: `set-handle-variant-${variant}`,
+        undo: () => apply(oldHandles),
+        redo: () => apply(newHandles),
+      })
+    }
   }
 
-  async function activateHandle(nodeId, handleUid) {
-    await setHandleVariant(nodeId, handleUid, HANDLE_VARIANT.DEFAULT)
+  async function activateHandle(nodeId, handleUid, options) {
+    await setHandleVariant(nodeId, handleUid, HANDLE_VARIANT.DEFAULT, options)
   }
 
   function beginGhostActivation(nodeId, handleUid) {
     pendingGhostRevert.value = { nodeId, handleUid }
-    activateHandle(nodeId, handleUid)
+    activateHandle(nodeId, handleUid, { trackHistory: false })
   }
 
   function confirmActivation() {
@@ -54,11 +59,14 @@ export function useHandleActivation() {
   /**
    * Reverts a single handle to the ghost variant, but only if no remaining
    * edge still terminates on it. `excludeEdgeIds` lets callers check this
-   * *before* the edge(s) being removed have actually left `edges.value`
-   * (e.g. inside onEdgeChange, ahead of applyEdgeChanges), so the check
-   * doesn't see its own soon-to-be-removed edge as "still in use".
+   * before the edge(s) being removed have actually left `edges.value`, so the 
+   * check doesn't see its own soon-to-be-removed edge as "still in use".
    */
-  async function revertHandleIfUnused(nodeId, handleUid, { excludeEdgeIds = [] } = {}) {
+  async function revertHandleIfUnused(
+    nodeId,
+    handleUid,
+    { excludeEdgeIds = [], trackHistory = true } = {}
+  ) {
     const node = getNodes.value.find((n) => n.id === nodeId)
     const handle = node?.data.handles.find((h) => h.uid === handleUid)
     if (!handle) return
@@ -72,7 +80,7 @@ export function useHandleActivation() {
     )
 
     if (!hasEdge) {
-      await setHandleVariant(nodeId, handleUid, HANDLE_VARIANT.GHOST)
+      await setHandleVariant(nodeId, handleUid, HANDLE_VARIANT.GHOST, { trackHistory })
     }
   }
 
@@ -82,7 +90,7 @@ export function useHandleActivation() {
     const { nodeId, handleUid } = pendingGhostRevert.value
     pendingGhostRevert.value = null
 
-    await revertHandleIfUnused(nodeId, handleUid)
+    await revertHandleIfUnused(nodeId, handleUid, { trackHistory: false })
   }
 
   /**
@@ -90,26 +98,30 @@ export function useHandleActivation() {
    * elsewhere). Pass the edge's own id(s) in excludeEdgeIds when calling
    * this ahead of the edge actually being removed from edges.value.
    */
-  async function revertHandlesForEdge(edge, excludeEdgeIds = [edge.id]) {
+  async function revertHandlesForEdge(edge, excludeEdgeIds = [edge.id], { trackHistory = true } = {}) {
     if (edge.sourceHandle) {
       await revertHandleIfUnused(edge.source, getHandleUidFromHandleId(edge.sourceHandle), {
         excludeEdgeIds,
+        trackHistory,
       })
     }
     if (edge.targetHandle) {
       await revertHandleIfUnused(edge.target, getHandleUidFromHandleId(edge.targetHandle), {
         excludeEdgeIds,
+        trackHistory,
       })
     }
   }
 
-  /** Re-activates both ends of a restored edge, e.g. on undo of a removal. */
-  async function reactivateEdgeHandles(edge) {
+  /**
+   * Re-activates both ends of a restored edge (e.g., on undo of a removal).
+   */
+  async function reactivateEdgeHandles(edge, { trackHistory = true } = {}) {
     if (edge.sourceHandle) {
-      await activateHandle(edge.source, getHandleUidFromHandleId(edge.sourceHandle))
+      await activateHandle(edge.source, getHandleUidFromHandleId(edge.sourceHandle), { trackHistory })
     }
     if (edge.targetHandle) {
-      await activateHandle(edge.target, getHandleUidFromHandleId(edge.targetHandle))
+      await activateHandle(edge.target, getHandleUidFromHandleId(edge.targetHandle), { trackHistory })
     }
   }
 

--- a/src/services/import/buildPorts.js
+++ b/src/services/import/buildPorts.js
@@ -1,41 +1,5 @@
 import { SOURCE_HANDLE_TYPE, TARGET_HANDLE_TYPE } from "../../utils/constants"
 
-function parseInstanceNames(connectedInstances) {
-  return Array.from(
-    new Set(connectedInstances?.trim().split(/\s+/).filter(Boolean) ?? [])
-  )
-}
-
-function buildHandles(instance) {
-  const handles = []
-
-  if (instance.inp_instances) {
-    const inputs = parseInstanceNames(instance.inp_instances)
-    inputs.forEach((name) => {
-      handles.push({
-        uid: crypto.randomUUID(),
-        type: TARGET_HANDLE_TYPE,
-        side: 'left',
-        name,
-      })
-    })
-  }
-
-  if (instance.out_instances) {
-    const outputs = parseInstanceNames(instance.out_instances)
-    outputs.forEach((name) => {
-      handles.push({
-        uid: crypto.randomUUID(),
-        type: SOURCE_HANDLE_TYPE,
-        side: 'right',
-        name,
-      })
-    })
-  }
-
-  return handles
-}
-
 function buildPorts(moduleData) {
   return Object.entries(moduleData)
     .filter(
@@ -55,4 +19,4 @@ function buildPorts(moduleData) {
     )
 }
 
-export { buildPorts, buildHandles }
+export { buildPorts }

--- a/src/services/import/buildWorkflow.js
+++ b/src/services/import/buildWorkflow.js
@@ -1,4 +1,4 @@
-import { getHandleId, buildHandles } from '../../utils/handles'
+import { getHandleId, buildHandles, buildGhostHandles } from '../../utils/handles'
 import { MAIN_NODE_TYPE, SOURCE_HANDLE_TYPE, TARGET_HANDLE_TYPE } from '../../utils/constants'
 import { extractVariablesFromMath } from '../../utils/cellml'
 import { resolvePortCouplings, checkAndClaimCouplings, buildUsedPortKeys } from '../../utils/edges'
@@ -49,8 +49,9 @@ function buildInstances(instanceRefs, availableModules, currentNodes, progressCa
     }
 
     const nodeType = MAIN_NODE_TYPE
-    const handles = buildHandles(instanceRef)
-
+    const ghostHandles = buildGhostHandles()
+    const handles = buildHandles(instanceRef, ghostHandles)
+    
     let position = null
     if (instanceRef.x !== undefined && instanceRef.y !== undefined) {
       position = { x: instanceRef.x, y: instanceRef.y }

--- a/src/services/import/buildWorkflow.js
+++ b/src/services/import/buildWorkflow.js
@@ -1,5 +1,4 @@
-import { buildHandles } from './buildPorts'
-import { getHandleId } from '../../utils/handles'
+import { getHandleId, buildHandles } from '../../utils/handles'
 import { MAIN_NODE_TYPE, SOURCE_HANDLE_TYPE, TARGET_HANDLE_TYPE } from '../../utils/constants'
 import { extractVariablesFromMath } from '../../utils/cellml'
 import { resolvePortCouplings, checkAndClaimCouplings, buildUsedPortKeys } from '../../utils/edges'

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -2,6 +2,10 @@ import { MarkerType } from '@vue-flow/core'
 
 export const SOURCE_HANDLE_TYPE = 'source'
 export const TARGET_HANDLE_TYPE = 'target'
+export const HANDLE_VARIANT = {
+  DEFAULT: 'default', 
+  GHOST: 'ghost',      
+}
 export const USER_MODULES_FILE = 'User_Modules.cellml'
 export const NEW_INSTANCE_MODULE_REF = 'new_module:phlynx'
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -7,7 +7,7 @@ export const HANDLE_VARIANT = {
   GHOST: 'ghost',      
 }
 export const NUM_GHOST_HANDLES_SIDES = 4
-export const NUM_GHOST_HANDLES_TOP_BOT = 6
+export const NUM_GHOST_HANDLES_TOP_BOT = 8
 export const HANDLE_SPACING = 30
 
 export const USER_MODULES_FILE = 'User_Modules.cellml'

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -6,6 +6,8 @@ export const HANDLE_VARIANT = {
   DEFAULT: 'default', 
   GHOST: 'ghost',      
 }
+export const NUM_GHOST_HANDLES = 16
+
 export const USER_MODULES_FILE = 'User_Modules.cellml'
 export const NEW_INSTANCE_MODULE_REF = 'new_module:phlynx'
 
@@ -19,7 +21,6 @@ export const edgeLineOptions = {
   markerEnd: markerEnd,
   style: {
     strokeWidth: 5,
-    // stroke: '#b1b1b7', // Can customize color if desired.
   },
 }
 export const FLOW_IDS = {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -6,9 +6,9 @@ export const HANDLE_VARIANT = {
   DEFAULT: 'default', 
   GHOST: 'ghost',      
 }
-export const NUM_GHOST_HANDLES_SIDES = 4
-export const NUM_GHOST_HANDLES_TOP_BOT = 8
-export const HANDLE_SPACING = 30
+export const NUM_GHOST_HANDLES_SIDES = 5
+export const NUM_GHOST_HANDLES_TOP_BOT = 7
+export const HANDLE_SPACING = 25
 
 export const USER_MODULES_FILE = 'User_Modules.cellml'
 export const NEW_INSTANCE_MODULE_REF = 'new_module:phlynx'

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -6,7 +6,8 @@ export const HANDLE_VARIANT = {
   DEFAULT: 'default', 
   GHOST: 'ghost',      
 }
-export const NUM_GHOST_HANDLES = 16
+export const NUM_GHOST_HANDLES_SIDES = 4
+export const NUM_GHOST_HANDLES_TOP_BOT = 6
 export const HANDLE_SPACING = 30
 
 export const USER_MODULES_FILE = 'User_Modules.cellml'

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -7,6 +7,7 @@ export const HANDLE_VARIANT = {
   GHOST: 'ghost',      
 }
 export const NUM_GHOST_HANDLES = 16
+export const HANDLE_SPACING = 30
 
 export const USER_MODULES_FILE = 'User_Modules.cellml'
 export const NEW_INSTANCE_MODULE_REF = 'new_module:phlynx'

--- a/src/utils/handles.js
+++ b/src/utils/handles.js
@@ -95,15 +95,14 @@ export function buildHandles(instanceRef) {
   return handles
 }
 
-export function buildGhostHandles(count = 16) {
-  const perSide = Math.floor(count / HANDLE_SIDES.length)
-  const remainder = count % HANDLE_SIDES.length
-
+export function buildGhostHandles(countTopBot = 5, countSides = 4) {
   const handles = []
 
   HANDLE_SIDES.forEach((side, sideIndex) => {
-    // spread any remainder across the first few sides so odd counts still work
-    const n = perSide + (sideIndex < remainder ? 1 : 0)
+    let n = countTopBot
+    if (side === "left" || side === "right"){
+      n = countSides
+    }
 
     for (let i = 0; i < n; i++) {
       handles.push({

--- a/src/utils/handles.js
+++ b/src/utils/handles.js
@@ -1,5 +1,11 @@
 import { Position } from '@vue-flow/core'
-import { HANDLE_SIDES, SOURCE_HANDLE_PRIORITY, TARGET_HANDLE_PRIORITY } from './constants'
+import {
+  HANDLE_SIDES,
+  SOURCE_HANDLE_PRIORITY,
+  TARGET_HANDLE_PRIORITY,
+  TARGET_HANDLE_TYPE,
+  SOURCE_HANDLE_TYPE
+} from './constants'
 
 export function randomHandleSide() {
     return HANDLE_SIDES[Math.floor(Math.random() * HANDLE_SIDES.length)]
@@ -49,4 +55,41 @@ export function getHandleStyle(handle, allHandles) {
   return {
     top: `calc(50% + ${offset}px)`,
   }
+}
+
+
+function parseInstanceNames(connectedInstances) {
+  return Array.from(
+    new Set(connectedInstances?.trim().split(/\s+/).filter(Boolean) ?? [])
+  )
+}
+
+export function buildHandles(instance) {
+  const handles = []
+
+  if (instance.inp_instances) {
+    const inputs = parseInstanceNames(instance.inp_instances)
+    inputs.forEach((name) => {
+      handles.push({
+        uid: crypto.randomUUID(),
+        type: TARGET_HANDLE_TYPE,
+        side: 'left',
+        name,
+      })
+    })
+  }
+
+  if (instance.out_instances) {
+    const outputs = parseInstanceNames(instance.out_instances)
+    outputs.forEach((name) => {
+      handles.push({
+        uid: crypto.randomUUID(),
+        type: SOURCE_HANDLE_TYPE,
+        side: 'right',
+        name,
+      })
+    })
+  }
+
+  return handles
 }

--- a/src/utils/handles.js
+++ b/src/utils/handles.js
@@ -9,11 +9,15 @@ import {
 } from './constants'
 
 export function randomHandleSide() {
-    return HANDLE_SIDES[Math.floor(Math.random() * HANDLE_SIDES.length)]
+  return HANDLE_SIDES[Math.floor(Math.random() * HANDLE_SIDES.length)]
 }
 
 export function getHandleId(handle) {
-    return `handle_${handle.uid}`
+  return `handle_${handle.uid}`
+}
+
+export function getHandleUidFromHandleId(handleId) {
+  return handleId.replace("handle_", "")
 }
 
 export function handlePosition(side) {

--- a/src/utils/handles.js
+++ b/src/utils/handles.js
@@ -66,11 +66,18 @@ function parseInstanceNames(connectedInstances) {
   )
 }
 
-export function buildHandles(instance) {
+/**
+ * Creates a list of handles for an instance node given the instance ref 
+ * defined in an instance array file.
+ * 
+ * @param {object} instanceRef 
+ * @returns {[handle]} handle 
+ */
+export function buildHandles(instanceRef) {
   const handles = []
 
-  if (instance.inp_instances) {
-    const inputs = parseInstanceNames(instance.inp_instances)
+  if (instanceRef.inp_instances) {
+    const inputs = parseInstanceNames(instanceRef.inp_instances)
     inputs.forEach((name) => {
       handles.push({
         uid: crypto.randomUUID(),
@@ -81,8 +88,8 @@ export function buildHandles(instance) {
     })
   }
 
-  if (instance.out_instances) {
-    const outputs = parseInstanceNames(instance.out_instances)
+  if (instanceRef.out_instances) {
+    const outputs = parseInstanceNames(instanceRef.out_instances)
     outputs.forEach((name) => {
       handles.push({
         uid: crypto.randomUUID(),

--- a/src/utils/handles.js
+++ b/src/utils/handles.js
@@ -33,7 +33,7 @@ export function handlePosition(side) {
 
 export function getHandleStyle(handle, allHandles) {
   const handlesOfSameType = allHandles.filter(
-    (h) => h.side === handle.side && h.variant === handle.variant
+    (h) => h.side === handle.side 
   )
   const n = handlesOfSameType.length
 

--- a/src/utils/handles.js
+++ b/src/utils/handles.js
@@ -4,7 +4,8 @@ import {
   SOURCE_HANDLE_PRIORITY,
   TARGET_HANDLE_PRIORITY,
   TARGET_HANDLE_TYPE,
-  SOURCE_HANDLE_TYPE
+  SOURCE_HANDLE_TYPE,
+  HANDLE_VARIANT,
 } from './constants'
 
 export function randomHandleSide() {
@@ -31,7 +32,9 @@ export function handlePosition(side) {
 }
 
 export function getHandleStyle(handle, allHandles) {
-  const handlesOfSameType = allHandles.filter((h) => h.side === handle.side)
+  const handlesOfSameType = allHandles.filter(
+    (h) => h.side === handle.side && h.variant === handle.variant
+  )
   const n = handlesOfSameType.length
 
   // Space between each port.
@@ -56,7 +59,6 @@ export function getHandleStyle(handle, allHandles) {
     top: `calc(50% + ${offset}px)`,
   }
 }
-
 
 function parseInstanceNames(connectedInstances) {
   return Array.from(
@@ -90,6 +92,29 @@ export function buildHandles(instance) {
       })
     })
   }
+
+  return handles
+}
+
+export function buildGhostHandles(count = 16) {
+  const perSide = Math.floor(count / HANDLE_SIDES.length)
+  const remainder = count % HANDLE_SIDES.length
+
+  const handles = []
+
+  HANDLE_SIDES.forEach((side, sideIndex) => {
+    // spread any remainder across the first few sides so odd counts still work
+    const n = perSide + (sideIndex < remainder ? 1 : 0)
+
+    for (let i = 0; i < n; i++) {
+      handles.push({
+        uid: crypto.randomUUID(),
+        side,
+        name: '',
+        variant: HANDLE_VARIANT.GHOST,
+      })
+    }
+  })
 
   return handles
 }

--- a/src/utils/handles.js
+++ b/src/utils/handles.js
@@ -6,6 +6,7 @@ import {
   TARGET_HANDLE_TYPE,
   SOURCE_HANDLE_TYPE,
   HANDLE_VARIANT,
+  HANDLE_SPACING,
 } from './constants'
 
 export function randomHandleSide() {
@@ -36,32 +37,19 @@ export function handlePosition(side) {
 }
 
 export function getHandleStyle(handle, allHandles) {
-  const handlesOfSameType = allHandles.filter(
-    (h) => h.side === handle.side 
-  )
+  const handlesOfSameType = allHandles.filter((h) => h.side === handle.side)
   const n = handlesOfSameType.length
 
-  // Space between each port.
-  const handleSpacing = 16
   const positionIndex = handlesOfSameType.findIndex((h) => h.uid === handle.uid)
-
-  // guard: if not found, fall back to 0
   const safeIndex = positionIndex === -1 ? 0 : positionIndex
 
-  // This calculates the offset from the center
-  const offset = handleSpacing * (positionIndex - (n - 1) / 2)
+  const offset = HANDLE_SPACING * (safeIndex - (n - 1) / 2)
 
   if (['top', 'bottom'].includes(handle.side)) {
-    // Let CSS calculate the 50% mark and apply the offset
-    return {
-      left: `calc(50% + ${offset}px)`,
-    }
+    return { left: `calc(50% + ${offset}px)` }
   }
 
-  // Let CSS calculate the 50% mark and apply the offset
-  return {
-    top: `calc(50% + ${offset}px)`,
-  }
+  return { top: `calc(50% + ${offset}px)` }
 }
 
 function parseInstanceNames(connectedInstances) {

--- a/src/utils/handles.js
+++ b/src/utils/handles.js
@@ -58,44 +58,65 @@ function parseInstanceNames(connectedInstances) {
   )
 }
 
-/**
- * Creates a list of handles for an instance node given the instance ref 
- * defined in an instance array file.
- * 
- * @param {object} instanceRef 
- * @returns {[handle]} handle 
- */
-export function buildHandles(instanceRef) {
-  const handles = []
+export function findMostCentralGhostHandle(side, allHandles) {
+  const handlesOnSide = allHandles.filter((h) => h.side === side)
+  const center = (handlesOnSide.length - 1) / 2
 
-  if (instanceRef.inp_instances) {
-    const inputs = parseInstanceNames(instanceRef.inp_instances)
-    inputs.forEach((name) => {
-      handles.push({
-        uid: crypto.randomUUID(),
-        type: TARGET_HANDLE_TYPE,
-        side: 'left',
-        name,
-      })
+  let mostCentral = null
+  let smallestDistance = Infinity
+
+  handlesOnSide.forEach((h, index) => {
+    if (h.variant !== HANDLE_VARIANT.GHOST) return
+    const distance = Math.abs(index - center)
+    if (distance < smallestDistance) {
+      smallestDistance = distance
+      mostCentral = h
+    }
+  })
+
+  return mostCentral
+}
+
+export function buildHandles(instanceRef, ghostHandles) {
+  const handles = ghostHandles.map((h) => ({ ...h }))
+
+  const promote = (names, type, side) => {
+    names.forEach((name) => {
+      const ghost = findMostCentralGhostHandle(side, handles)
+
+      if (!ghost) {
+        console.warn(
+          `[buildHandles] No free "${side}" ghost slot for "${name}" on instance ` +
+            `"${instanceRef.name}" — exceeds the per-edge handle limit. Adding an overflow handle.`
+        )
+        handles.push({
+          uid: crypto.randomUUID(),
+          type,
+          side,
+          name,
+          variant: HANDLE_VARIANT.DEFAULT,
+        })
+        return
+      }
+
+      ghost.type = type
+      ghost.name = name
+      ghost.variant = HANDLE_VARIANT.DEFAULT
     })
   }
 
+  if (instanceRef.inp_instances) {
+    promote(parseInstanceNames(instanceRef.inp_instances), TARGET_HANDLE_TYPE, 'top')
+  }
+
   if (instanceRef.out_instances) {
-    const outputs = parseInstanceNames(instanceRef.out_instances)
-    outputs.forEach((name) => {
-      handles.push({
-        uid: crypto.randomUUID(),
-        type: SOURCE_HANDLE_TYPE,
-        side: 'right',
-        name,
-      })
-    })
+    promote(parseInstanceNames(instanceRef.out_instances), SOURCE_HANDLE_TYPE, 'bottom')
   }
 
   return handles
 }
 
-export function buildGhostHandles(countTopBot = 5, countSides = 4) {
+export function buildGhostHandles(countTopBot = 7, countSides = 5) {
   const handles = []
 
   HANDLE_SIDES.forEach((side, sideIndex) => {

--- a/src/utils/handles.js
+++ b/src/utils/handles.js
@@ -137,3 +137,11 @@ export function buildGhostHandles(countTopBot = 7, countSides = 5) {
 
   return handles
 }
+
+export function isCornerHandle(handle, allHandles) {
+  const handlesOfSameType = allHandles.filter((h) => h.side === handle.side)
+  const n = handlesOfSameType.length
+  const positionIndex = handlesOfSameType.findIndex((h) => h.uid === handle.uid)
+
+  return positionIndex === 0 || positionIndex === n - 1
+}

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -362,7 +362,7 @@ export default {
 
 <script setup>
 import { computed, h, inject, markRaw, nextTick, onMounted, onUnmounted, ref, watch, watchPostEffect } from 'vue'
-import { connectionExists, useVueFlow, VueFlow } from '@vue-flow/core'
+import { connectionExists, useHandle, useVueFlow, VueFlow } from '@vue-flow/core'
 
 import Button from 'primevue/button'
 import SplitButton from 'primevue/splitbutton'
@@ -379,7 +379,7 @@ import { MiniMap } from '@vue-flow/minimap'
 import { useLibraryStore } from '../stores/libraryStore'
 import { useFlowHistoryStore } from '../stores/historyStore'
 import useDragAndDrop from '../composables/useDnD'
-import { useHandleActivation } from '../composables/useHandleActivation'
+import { useHandleManagement } from '../composables/useHandleManagement'
 import { useLoadFromInstanceArray } from '../composables/useLoadFromInstanceArray'
 import { useLoadFromCellML } from '../composables/useLoadFromCellml'
 import { parseCellMLConnections } from '../services/import/parseCellmlConnections'
@@ -489,7 +489,7 @@ const {
 } = useDragAndDrop(pendingHistoryNodes)
 
 const { activateHandle, confirmActivation, revertPendingGhostIfUnused, revertHandlesForEdge, reactivateEdgeHandles } =
-  useHandleActivation()
+  useHandleManagement()
 
 const dialogVisible = computed(() => {
   return (
@@ -893,7 +893,7 @@ onConnect(async (connection) => {
       rejectLabel: 'Cancel',
     })
 
-    removeEdges(pendingEdge.id) 
+    removeEdges(pendingEdge.id)
     suppressedEdgeIds.delete(pendingEdge.id)
 
     if (!shouldReplace) return
@@ -954,15 +954,15 @@ onConnect(async (connection) => {
       type: 'replace-edge',
       undo: () => {
         removeEdges(newEdge.id)
-        revertHandlesForEdge(newEdge)
+        revertHandlesForEdge(newEdge, [newEdge.id], { trackHistory: false })
         addEdges(duplicateSnapshot)
-        reactivateEdgeHandles(duplicateSnapshot)
+        reactivateEdgeHandles(duplicateSnapshot, { trackHistory: false })
       },
       redo: () => {
         removeEdges(duplicateSnapshot.id)
-        revertHandlesForEdge(duplicateSnapshot)
+        revertHandlesForEdge(duplicateSnapshot, [duplicateSnapshot.id], { trackHistory: false })
         addEdges(newEdge)
-        reactivateEdgeHandles(newEdge)
+        reactivateEdgeHandles(newEdge, { trackHistory: false })
       },
     })
   } else {
@@ -1300,7 +1300,6 @@ const onNodeChange = (changes) => {
   applyNodeChanges(changes)
 }
 
-// Ignore pending edges in history store
 const suppressedEdgeIds = new Set()
 
 const onEdgeChange = (changes) => {
@@ -1333,8 +1332,16 @@ const onEdgeChange = (changes) => {
     const edgesToRestore = addChanges.map((change) => change.edge)
     const idsToRemove = addChanges.map((change) => change.edge.id)
     historyStore.addCommand({
-      undo: () => removeEdges(idsToRemove),
-      redo: () => addEdges(edgesToRestore),
+      undo: () => {
+        removeEdges(idsToRemove)
+        edgesToRestore.forEach((edge) =>
+          revertHandlesForEdge(edge, idsToRemove, { trackHistory: false })
+        )
+      },
+      redo: () => {
+        addEdges(edgesToRestore)
+        edgesToRestore.forEach((edge) => reactivateEdgeHandles(edge, { trackHistory: false }))
+      },
     })
   }
 
@@ -1342,17 +1349,21 @@ const onEdgeChange = (changes) => {
     const edgesToRestore = removeChanges.map((change) => change.edge)
     const idsToRemove = removeChanges.map((change) => change.edge.id)
 
-    // Ghost out any handle that no longer has an edge attached
+    // Ghost out any handle that no longer has an edge attached to it. 
+    // excludeEdgeIds is passed because edges.value hasn't actually 
+    // dropped these ids yet at this point.
     edgesToRestore.forEach((edge) => revertHandlesForEdge(edge, idsToRemove))
 
     historyStore.addCommand({
       undo: () => {
         addEdges(edgesToRestore)
-        edgesToRestore.forEach(reactivateEdgeHandles)
+        edgesToRestore.forEach((edge) => reactivateEdgeHandles(edge, { trackHistory: false }))
       },
       redo: () => {
         removeEdges(idsToRemove)
-        edgesToRestore.forEach((edge) => revertHandlesForEdge(edge, idsToRemove))
+        edgesToRestore.forEach((edge) =>
+          revertHandlesForEdge(edge, idsToRemove, { trackHistory: false })
+        )
       },
     })
   }

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -465,6 +465,7 @@ const {
   getSelectedEdges,
   nodes,
   onConnect,
+  onConnectEnd,
   removeEdges,
   removeNodes,
   screenToFlowCoordinate,
@@ -487,7 +488,7 @@ const {
   createInstanceNode,
 } = useDragAndDrop(pendingHistoryNodes)
 
-const { activateHandle } = useHandleActivation()
+const { activateHandle, confirmActivation, revertPendingGhostIfUnused } = useHandleActivation()
 
 const dialogVisible = computed(() => {
   return (
@@ -853,6 +854,10 @@ const currentExportMode = computed(() => {
   return found || exportOptions.value[0]
 })
 
+onConnectEnd(() => {
+  revertPendingGhostIfUnused()
+})
+
 onConnect((connection) => {
   const sourceNode = findNode(connection.source)
   const targetNode = findNode(connection.target)
@@ -878,6 +883,7 @@ onConnect((connection) => {
     targetIndex
   )
 
+  confirmActivation()
   if (connection.sourceHandle) {
     activateHandle(connection.source, getHandleUidFromHandleId(connection.sourceHandle))
   }

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -488,7 +488,14 @@ const {
   createInstanceNode,
 } = useDragAndDrop(pendingHistoryNodes)
 
-const { activateHandle, confirmActivation, revertPendingGhostIfUnused, revertHandlesForEdge, reactivateEdgeHandles } =
+const {
+  activateHandle,
+  confirmActivation,
+  revertPendingGhostIfUnused,
+  revertHandlesForEdge,
+  reactivateEdgeHandles,
+  revertHandleIfUnused,
+} =
   useHandleManagement()
 
 const dialogVisible = computed(() => {
@@ -913,9 +920,8 @@ onConnect(async (connection) => {
     suppressedEdgeIds.delete(pendingEdge.id)
 
     if (!shouldReplace) {
-      // No edge new is being created so revert the handles activated above.
-      if (sourceHandleUid) revertHandleIfUnused(connection.source, sourceHandleUid)
-      if (targetHandleUid) revertHandleIfUnused(connection.target, targetHandleUid)
+      if (sourceHandleUid) revertHandleIfUnused(connection.source, sourceHandleUid, { trackHistory: false })
+      if (targetHandleUid) revertHandleIfUnused(connection.target, targetHandleUid, { trackHistory: false })
       return
     }
 

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -379,6 +379,7 @@ import { MiniMap } from '@vue-flow/minimap'
 import { useLibraryStore } from '../stores/libraryStore'
 import { useFlowHistoryStore } from '../stores/historyStore'
 import useDragAndDrop from '../composables/useDnD'
+import { useHandleActivation } from '../composables/useHandleActivation'
 import { useLoadFromInstanceArray } from '../composables/useLoadFromInstanceArray'
 import { useLoadFromCellML } from '../composables/useLoadFromCellml'
 import { parseCellMLConnections } from '../services/import/parseCellmlConnections'
@@ -443,6 +444,7 @@ import CellMLEditorDialog from '../components/CellMLEditorDialog.vue'
 import ParameterEditorDialog from '../components/ParameterEditorDialog.vue'
 import PortEditorDialog from '../components/PortEditorDialog.vue'
 import CellMLIcon from '../components/icons/CellMLIcon.vue'
+import { getHandleId, getHandleUidFromHandleId } from '../utils/handles'
 
 const workspaceFileInput = ref(null)
 
@@ -484,6 +486,8 @@ const {
   isDragOver,
   createInstanceNode,
 } = useDragAndDrop(pendingHistoryNodes)
+
+const { activateHandle } = useHandleActivation()
 
 const dialogVisible = computed(() => {
   return (
@@ -873,6 +877,14 @@ onConnect((connection) => {
     sourceIndex,
     targetIndex
   )
+
+  if (connection.sourceHandle) {
+    activateHandle(connection.source, getHandleUidFromHandleId(connection.sourceHandle))
+  }
+
+  if (connection.targetHandle) {
+    activateHandle(connection.target, getHandleUidFromHandleId(connection.targetHandle))
+  }
 
   const newEdge = {
     ...connection,

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -488,7 +488,8 @@ const {
   createInstanceNode,
 } = useDragAndDrop(pendingHistoryNodes)
 
-const { activateHandle, confirmActivation, revertPendingGhostIfUnused } = useHandleActivation()
+const { activateHandle, confirmActivation, revertPendingGhostIfUnused, revertHandlesForEdge, reactivateEdgeHandles } =
+  useHandleActivation()
 
 const dialogVisible = computed(() => {
   return (
@@ -889,7 +890,10 @@ onConnect(async (connection) => {
 
     removeEdges(pendingEdge.id) 
 
-    if (!shouldReplace) return  
+    if (!shouldReplace) {
+      
+      return  
+    }
     removeEdges(duplicate.id)    
   }
 
@@ -1298,9 +1302,19 @@ const onEdgeChange = (changes) => {
   if (removeChanges.length) {
     const edgesToRestore = removeChanges.map((change) => change.edge)
     const idsToRemove = removeChanges.map((change) => change.edge.id)
+
+    // Ghost out any handle that no longer has an edge attached
+    edgesToRestore.forEach((edge) => revertHandlesForEdge(edge, idsToRemove))
+
     historyStore.addCommand({
-      undo: () => addEdges(edgesToRestore),
-      redo: () => removeEdges(idsToRemove),
+      undo: () => {
+        addEdges(edgesToRestore)
+        edgesToRestore.forEach(reactivateEdgeHandles)
+      },
+      redo: () => {
+        removeEdges(idsToRemove)
+        edgesToRestore.forEach((edge) => revertHandlesForEdge(edge, idsToRemove))
+      },
     })
   }
 

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -870,12 +870,17 @@ onConnect(async (connection) => {
     (e) => e.source === connection.source && e.target === connection.target
   )
 
+  const duplicateSnapshot = duplicate ? detachReactivity(duplicate) : null
+
   if (duplicate) {
     const pendingEdge = {
       ...connection,
       id: `pending--${connection.source}--${connection.target}`,
       style: { strokeDasharray: '8 8', opacity: 0.4 }, // visually mark "unconfirmed"
     }
+
+    // Prevents addition to history store.
+    suppressedEdgeIds.add(pendingEdge.id)
     addEdges(pendingEdge)
 
     const shouldReplace = await confirm({
@@ -889,12 +894,13 @@ onConnect(async (connection) => {
     })
 
     removeEdges(pendingEdge.id) 
+    suppressedEdgeIds.delete(pendingEdge.id)
 
-    if (!shouldReplace) {
-      
-      return  
-    }
-    removeEdges(duplicate.id)    
+    if (!shouldReplace) return
+
+    suppressedEdgeIds.add(duplicate.id)
+    removeEdges(duplicate.id)
+    revertHandlesForEdge(duplicateSnapshot)
   }
 
   // Derive ordinal indices from the existing edge graph:
@@ -935,7 +941,33 @@ onConnect(async (connection) => {
     },
   }
 
-  addEdges(newEdge)
+  if (duplicateSnapshot) {
+    suppressedEdgeIds.add(newEdge.id)
+    addEdges(newEdge)
+    suppressedEdgeIds.delete(duplicateSnapshot.id)
+    suppressedEdgeIds.delete(newEdge.id)
+
+    // A single undo step for the whole replace: undo brings the old edge
+    // (and its handle activation) back and removes the new one; redo does
+    // the reverse. 
+    historyStore.addCommand({
+      type: 'replace-edge',
+      undo: () => {
+        removeEdges(newEdge.id)
+        revertHandlesForEdge(newEdge)
+        addEdges(duplicateSnapshot)
+        reactivateEdgeHandles(duplicateSnapshot)
+      },
+      redo: () => {
+        removeEdges(duplicateSnapshot.id)
+        revertHandlesForEdge(duplicateSnapshot)
+        addEdges(newEdge)
+        reactivateEdgeHandles(newEdge)
+      },
+    })
+  } else {
+    addEdges(newEdge)
+  }
 })
 
 const createSelectCommand = (changes, findFn) => {
@@ -1268,6 +1300,9 @@ const onNodeChange = (changes) => {
   applyNodeChanges(changes)
 }
 
+// Ignore pending edges in history store
+const suppressedEdgeIds = new Set()
+
 const onEdgeChange = (changes) => {
   if (historyStore.isUndoRedoing) {
     // If we are currently undoing/redoing, bypass history tracking
@@ -1280,10 +1315,14 @@ const onEdgeChange = (changes) => {
   changes.forEach((c) => {
     if (c.type === 'remove') {
       indexRemoveEdge(c)
-      removeChanges.push({ edge: snapshotEdge(c) })
+      if (!suppressedEdgeIds.has(c.id)) {
+        removeChanges.push({ edge: snapshotEdge(c) })
+      }
     } else if (c.type === 'add') {
       indexAddEdge(c.item)
-      addChanges.push({ edge: snapshotEdge(c) })
+      if (!suppressedEdgeIds.has(c.item.id)) {
+        addChanges.push({ edge: snapshotEdge(c) })
+      }
     } else if (c.type === 'select' && undoRedoSelection) {
       const edge = findEdge(c.id)
       selectChanges.push({ id: c.id, from: edge.selected, to: c.selected })

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -362,7 +362,7 @@ export default {
 
 <script setup>
 import { computed, h, inject, markRaw, nextTick, onMounted, onUnmounted, ref, watch, watchPostEffect } from 'vue'
-import { useVueFlow, VueFlow } from '@vue-flow/core'
+import { connectionExists, useVueFlow, VueFlow } from '@vue-flow/core'
 
 import Button from 'primevue/button'
 import SplitButton from 'primevue/splitbutton'
@@ -858,12 +858,40 @@ onConnectEnd(() => {
   revertPendingGhostIfUnused()
 })
 
-onConnect((connection) => {
+onConnect(async (connection) => {
   const sourceNode = findNode(connection.source)
   const targetNode = findNode(connection.target)
 
   if (!sourceNode || !targetNode) return
   if (sourceNode === targetNode) return
+
+  const duplicate = edges.value.find(
+    (e) => e.source === connection.source && e.target === connection.target
+  )
+
+  if (duplicate) {
+    const pendingEdge = {
+      ...connection,
+      id: `pending--${connection.source}--${connection.target}`,
+      style: { strokeDasharray: '8 8', opacity: 0.4 }, // visually mark "unconfirmed"
+    }
+    addEdges(pendingEdge)
+
+    const shouldReplace = await confirm({
+      header: 'Connection already exists',
+      message:
+        'A connection already exists between these instances. Do you wish to replace it?\n\n' +
+        'If you select Cancel, the new connection will be discarded and the existing connection will remain.',
+      severity: 'warning',
+      acceptLabel: 'Replace',
+      rejectLabel: 'Cancel',
+    })
+
+    removeEdges(pendingEdge.id) 
+
+    if (!shouldReplace) return  
+    removeEdges(duplicate.id)    
+  }
 
   // Derive ordinal indices from the existing edge graph:
   //   sourceIndex = how many edges already leave from this source node

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -362,7 +362,7 @@ export default {
 
 <script setup>
 import { computed, h, inject, markRaw, nextTick, onMounted, onUnmounted, ref, watch, watchPostEffect } from 'vue'
-import { connectionExists, useHandle, useVueFlow, VueFlow } from '@vue-flow/core'
+import { connectionExists, useVueFlow, VueFlow } from '@vue-flow/core'
 
 import Button from 'primevue/button'
 import SplitButton from 'primevue/splitbutton'
@@ -872,6 +872,22 @@ onConnect(async (connection) => {
 
   const duplicateSnapshot = duplicate ? detachReactivity(duplicate) : null
 
+  const sourceHandleUid = connection.sourceHandle
+    ? getHandleUidFromHandleId(connection.sourceHandle)
+    : null
+  const targetHandleUid = connection.targetHandle
+    ? getHandleUidFromHandleId(connection.targetHandle)
+    : null
+
+  confirmActivation()
+
+  if (sourceHandleUid) {
+    activateHandle(connection.source, sourceHandleUid, { trackHistory: false })
+  }
+  if (targetHandleUid) {
+    activateHandle(connection.target, targetHandleUid, { trackHistory: false })
+  }
+
   if (duplicate) {
     const pendingEdge = {
       ...connection,
@@ -896,7 +912,12 @@ onConnect(async (connection) => {
     removeEdges(pendingEdge.id)
     suppressedEdgeIds.delete(pendingEdge.id)
 
-    if (!shouldReplace) return
+    if (!shouldReplace) {
+      // No edge new is being created so revert the handles activated above.
+      if (sourceHandleUid) revertHandleIfUnused(connection.source, sourceHandleUid)
+      if (targetHandleUid) revertHandleIfUnused(connection.target, targetHandleUid)
+      return
+    }
 
     suppressedEdgeIds.add(duplicate.id)
     removeEdges(duplicate.id)
@@ -921,15 +942,6 @@ onConnect(async (connection) => {
     targetIndex
   )
 
-  confirmActivation()
-  if (connection.sourceHandle) {
-    activateHandle(connection.source, getHandleUidFromHandleId(connection.sourceHandle))
-  }
-
-  if (connection.targetHandle) {
-    activateHandle(connection.target, getHandleUidFromHandleId(connection.targetHandle))
-  }
-
   const newEdge = {
     ...connection,
     ...edgeLineOptions,
@@ -949,7 +961,7 @@ onConnect(async (connection) => {
 
     // A single undo step for the whole replace: undo brings the old edge
     // (and its handle activation) back and removes the new one; redo does
-    // the reverse. 
+    // the reverse. No pending edge involved on either side.
     historyStore.addCommand({
       type: 'replace-edge',
       undo: () => {


### PR DESCRIPTION
Introduced a second handle variant (ghost) that becomes active on pointer down or on connect. Consolidated this activation into a composable, which is called when adding a handle through the button on the instance node. 

Deleting handles also restores them to ghost mode. Activated ghost handles that don't become part of a connection are reverted to ghost handles on connect end.

Addressed most of the implications for the automated workflow builders, but updating the layout calculators was beyond me (sometimes the automated layouts aren't so nice because the handles get redistributed in a funky way). Might be worth resolving this before merging? But it could also be ok for now.

Also introduces an inert ghost variant on node selection to deal with the steric clash between ghost handles and the node resizer tools.

Resolves #488 & Resolves #300 