### PR TITLE
Consolidate editor dialogs

### DIFF
--- a/src/components/CellMLTextEditor.vue
+++ b/src/components/CellMLTextEditor.vue
@@ -170,12 +170,14 @@ const applyFitScale = () => {
   if (!content) return
 
   const containerWidth = container.clientWidth - 30
-  if (containerWidth <= 0) return
+  const containerHeight = container.clientHeight - 10
+  if (containerWidth <= 0 || containerHeight <=0) return
 
   const contentWidth = content.scrollWidth
+  const contentHeight = content.scrollHeight
 
-  if (contentWidth > containerWidth) {
-    const rawScale = containerWidth / contentWidth
+  if (contentHeight > containerHeight || contentWidth > containerWidth) {
+    const rawScale = Math.min(containerWidth / contentWidth, containerHeight / contentHeight)
     const scale = Math.max(rawScale * 0.95, MIN_FIT_SCALE)
     content.style.transform = `scale(${scale})`
     content.style.transformOrigin = 'center center'

--- a/src/components/CellMLTextEditor.vue
+++ b/src/components/CellMLTextEditor.vue
@@ -9,10 +9,35 @@
       <div v-else class="preview-pane" ref="latexContainer"></div>
 
       <div class="panel">
-        <h3>CellML Text</h3>
+        <div class="panel-header">
+          <h3>CellML Text</h3>
+          <div class="font-size-control" role="group" aria-label="Editor font size">
+            <button
+              type="button"
+              class="font-size-btn"
+              :disabled="fontSize <= MIN_FONT_SIZE"
+              title="Decrease font size"
+              aria-label="Decrease font size"
+              @click="decreaseFontSize"
+            >
+              <i class="pi pi-minus" style="font-size: 0.7rem"></i>
+            </button>
+            <span class="font-size-value">{{ fontSize }}px</span>
+            <button
+              type="button"
+              class="font-size-btn"
+              :disabled="fontSize >= MAX_FONT_SIZE"
+              title="Increase font size"
+              aria-label="Increase font size"
+              @click="increaseFontSize"
+            >
+              <i class="pi pi-plus" style="font-size: 0.7rem"></i>
+            </button>
+          </div>
+        </div>
         <codemirror
           v-model="cellmlText"
-          :style="{ height: '400px' }"
+          :style="{ height: '400px', '--cm-font-size': fontSize + 'px' }"
           :autofocus="true"
           :indent-with-tab="true"
           :tab-size="2"
@@ -66,6 +91,42 @@ const cursorLine = ref(1)
 const latexPreview = ref('')
 
 const MIN_FIT_SCALE = 0.55
+const MIN_FONT_SIZE = 10
+const MAX_FONT_SIZE = 20
+const FONT_SIZE_STORAGE_KEY = 'cellml-editor-font-size'
+const DEFAULT_FONT_SIZE = 12.5
+
+function loadStoredFontSize() {
+  try {
+    const stored = Number(window.localStorage.getItem(FONT_SIZE_STORAGE_KEY))
+    if (stored && stored >= MIN_FONT_SIZE && stored <= MAX_FONT_SIZE) {
+      return stored
+    }
+  } catch (e) {
+    // localStorage unavailable (e.g. private browsing) - fall back to default
+  }
+  return DEFAULT_FONT_SIZE
+}
+
+const fontSize = ref(loadStoredFontSize())
+
+function persistFontSize() {
+  try {
+    window.localStorage.setItem(FONT_SIZE_STORAGE_KEY, String(fontSize.value))
+  } catch (e) {
+    // ignore storage errors
+  }
+}
+
+function increaseFontSize() {
+  fontSize.value = Math.min(MAX_FONT_SIZE, fontSize.value + 1)
+  persistFontSize()
+}
+
+function decreaseFontSize() {
+  fontSize.value = Math.max(MIN_FONT_SIZE, fontSize.value - 1)
+  persistFontSize()
+}
 
 // ── Dynamic Dark Mode Detection ─────────────────────────────────────────────
 const isDarkMode = ref(false)
@@ -260,11 +321,59 @@ onUnmounted(() => {
   color: var(--p-text-color);
 }
 
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.font-size-control {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 6px;
+  padding: 2px;
+}
+
+.font-size-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: none;
+  border-radius: 4px;
+  background: none;
+  color: var(--p-text-muted-color);
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.font-size-btn:hover:not(:disabled) {
+  background: var(--p-content-hover-background, rgba(255, 255, 255, 0.06));
+  color: var(--p-text-color);
+}
+
+.font-size-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.font-size-value {
+  font-size: 0.75rem;
+  color: var(--p-text-muted-color);
+  min-width: 2.6em;
+  text-align: center;
+  user-select: none;
+}
+
 /* CodeMirror Base Styling */
 :deep(.cm-editor) {
   flex: 1;
   border-radius: 6px;
-  font-size: 14px;
+  font-size: var(--cm-font-size, 11.5px);
   overflow: hidden;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   background-color: var(--p-content-background);

--- a/src/components/CellMLTextEditor.vue
+++ b/src/components/CellMLTextEditor.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container">
+  <div class="container" ref="rootRef">
     <div class="panel">
       <div v-if="errors.length > 0" class="error-banner">
         <div v-for="(err, index) in errors" :key="index">
@@ -56,11 +56,16 @@ const latexGen = new CellMLLatexGenerator()
 const cellmlText = ref(generator.generate(props.modelValue))
 const errors = ref([])
 const latexContainer = ref(null)
+const rootRef = ref(null)
 
 let debouncer = null
 let currentDoc = null
+let resizeObserver = null
+let resizeRaf = null
 const cursorLine = ref(1)
 const latexPreview = ref('')
+
+const MIN_FIT_SCALE = 0.55
 
 // ── Dynamic Dark Mode Detection ─────────────────────────────────────────────
 const isDarkMode = ref(false)
@@ -96,6 +101,33 @@ const extensions = computed(() => {
   return isDarkMode.value ? [...base, oneDark] : base
 })
 
+const applyFitScale = () => {
+  const container = latexContainer.value
+  if (!container) return
+
+  const content = container.querySelector('.katex-html')
+  if (!content) return
+
+  const containerWidth = container.clientWidth - 30
+  if (containerWidth <= 0) return
+
+  const contentWidth = content.scrollWidth
+
+  if (contentWidth > containerWidth) {
+    const rawScale = containerWidth / contentWidth
+    const scale = Math.max(rawScale * 0.95, MIN_FIT_SCALE)
+    content.style.transform = `scale(${scale})`
+    content.style.transformOrigin = 'center center'
+  } else {
+    content.style.transform = 'none'
+  }
+}
+
+const scheduleFitScale = () => {
+  if (resizeRaf) cancelAnimationFrame(resizeRaf)
+  resizeRaf = requestAnimationFrame(applyFitScale)
+}
+
 const updatePreview = async () => {
   if (!currentDoc) return
 
@@ -128,23 +160,7 @@ const updatePreview = async () => {
     latexPreview.value = latex
     if (latexContainer.value) {
       katex.render(latex, latexContainer.value, { throwOnError: false, displayMode: true })
-      nextTick(() => {
-        const container = latexContainer.value
-        const content = container.querySelector('.katex-html')
-
-        if (content) {
-          const containerWidth = container.clientWidth - 30
-          const contentWidth = content.scrollWidth
-
-          if (contentWidth > containerWidth) {
-            const scale = containerWidth / contentWidth
-            content.style.transform = `scale(${scale * 0.95})`
-            content.style.transformOrigin = 'center center'
-          } else {
-            content.style.transform = 'none'
-          }
-        }
-      })
+      nextTick(applyFitScale)
     }
   } else {
     latexPreview.value = ''
@@ -199,10 +215,16 @@ onMounted(() => {
   }
 
   window.addEventListener('keydown', handleKeyDown)
+  if (rootRef.value && typeof ResizeObserver !== 'undefined') {
+    resizeObserver = new ResizeObserver(scheduleFitScale)
+    resizeObserver.observe(rootRef.value)
+  }
 })
 
 onUnmounted(() => {
   if (observer) observer.disconnect()
+  if (resizeObserver) resizeObserver.disconnect()
+  if (resizeRaf) cancelAnimationFrame(resizeRaf)
   window.removeEventListener('keydown', handleKeyDown)
 })
 </script>
@@ -228,6 +250,7 @@ onUnmounted(() => {
   flex-direction: column;
   min-height: 0;
   gap: 12px;
+  --eq-preview-height: clamp(170px, 24vh, 280px);
 }
 
 .panel h3 {
@@ -283,7 +306,7 @@ onUnmounted(() => {
 
 /* LaTeX Preview Area - Adapts to Dark Mode */
 .preview-pane {
-  height: 110px;
+  height: var(--eq-preview-height);
   padding: 15px;
   background-color: color-mix(in srgb, var(--p-content-background) 96%, var(--p-text-color));
   border: 1px solid var(--p-content-border-color);
@@ -292,8 +315,23 @@ onUnmounted(() => {
   align-items: center;
   justify-content: center;
   font-size: 1.4em;
-  overflow: hidden;
+  overflow: auto;
   color: var(--p-text-color);
+  scrollbar-width: thin;
+}
+
+.preview-pane::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.preview-pane::-webkit-scrollbar-thumb {
+  background-color: var(--p-content-border-color);
+  border-radius: 4px;
+}
+
+.preview-pane::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 .preview-pane :deep(.katex) {
@@ -323,7 +361,7 @@ onUnmounted(() => {
   border-radius: 6px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 0.85em;
-  height: 110px;
+  height: var(--eq-preview-height);
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/components/CellMLTextEditor.vue
+++ b/src/components/CellMLTextEditor.vue
@@ -90,7 +90,7 @@ let resizeRaf = null
 const cursorLine = ref(1)
 const latexPreview = ref('')
 
-const MIN_FIT_SCALE = 0.55
+const MIN_FIT_SCALE = 0.50
 const MIN_FONT_SIZE = 10
 const MAX_FONT_SIZE = 20
 const FONT_SIZE_STORAGE_KEY = 'cellml-editor-font-size'
@@ -380,6 +380,7 @@ onUnmounted(() => {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   background-color: var(--p-content-background);
   color: var(--p-text-color);
+  outline:none;
   border: 1px solid var(--p-content-border-color);
 }
 

--- a/src/components/CellMLTextEditor.vue
+++ b/src/components/CellMLTextEditor.vue
@@ -232,9 +232,12 @@ const updatePreview = async () => {
 }
 
 const handleKeyDown = (event) => {
-  if ((event.ctrlKey || event.metaKey) && event.key === 's') {
+  if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
     event.preventDefault()
     handleSave()
+  }
+  if ((event.ctrlKey || event.metaKey) && event.key === 's') {
+    event.preventDefault()
   }
 }
 

--- a/src/components/InstanceEditorDialog.vue
+++ b/src/components/InstanceEditorDialog.vue
@@ -824,6 +824,7 @@ async function handleSave() {
   gap: 0;
   flex: 1 1 auto;
   min-height: 0;
+  height: 100%;
   max-height: 100%;
   max-width: 100%;
   transition: filter 0.2s ease, opacity 0.2s ease;

--- a/src/components/InstanceEditorDialog.vue
+++ b/src/components/InstanceEditorDialog.vue
@@ -352,7 +352,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onBeforeUnmount, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, onBeforeUnmount, onMounted, onUnmounted, nextTick } from 'vue'
 import { useVueFlow } from '@vue-flow/core'
 
 import Button from 'primevue/button'
@@ -633,6 +633,7 @@ watch(
       } catch (e) {
         console.error('Failed to load CellML source', e)
       } finally {
+        await nextTick()
         loading.value = false
       }
     }

--- a/src/components/InstanceEditorDialog.vue
+++ b/src/components/InstanceEditorDialog.vue
@@ -681,7 +681,7 @@ async function handleSave() {
   })
 
   // Emit consolidated payload to parent workspace
-  emit('save', {
+  emit('confirm', {
     id: props.id,
     name: editableName.value,
     mathRef: newMathRef,

--- a/src/components/InstanceEditorDialog.vue
+++ b/src/components/InstanceEditorDialog.vue
@@ -15,7 +15,7 @@
 
     <div v-else class="editor-grid" ref="editorGridRef" :class="{ 'is-dragging': dragging }">
       <!-- LEFT COLUMN: CellML Text Editor -->
-      <div class="pane left-pane" :style="leftPaneStyle">
+      <div class="pane left-pane" :style="leftPaneStyle" :class="{ 'left-pane--collapsed': rightCollapsed }">
         <div class="editor-wrapper">
           <CellMLTextEditor
             :key="mathRef"
@@ -619,6 +619,7 @@ async function handleSave() {
     activeTab.value = 'ports'
     return
   }
+
   const sanitised = sanitiseName(editableName.value)
   if (!sanitised) {
     notify.error({ message: 'Instance name is invalid.' })
@@ -698,9 +699,10 @@ async function handleSave() {
 
 <style scoped>
 .module-editor-dialog {
-  display: flex !important;
-  flex-direction: column !important;
-  overflow: hidden !important;
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+  box-sizing: border-box;
 }
 
 .module-editor-dialog :deep(.p-dialog-content) {
@@ -712,7 +714,6 @@ async function handleSave() {
   padding-bottom: 16px !important;
 }
 
-/* ── Design tokens (kept local to this dialog for consistent typography) ── */
 .editor-grid {
   --dlg-fs-label: 0.875rem;   /* 14px - field/section labels */
   --dlg-fs-body: 0.875rem;    /* 14px - table cells, inputs */
@@ -724,7 +725,8 @@ async function handleSave() {
   gap: 0;
   flex: 1 1 auto;
   min-height: 0;
-  height: clamp(520px, 69vh, 940px);
+  max-height: 100%;
+  max-width: 100%;
 }
 
 .editor-grid.is-dragging {
@@ -745,7 +747,12 @@ async function handleSave() {
 }
 
 .left-pane {
-  min-width: 340px;
+  min-width: 38%;
+  max-width: 67%;
+}
+
+.left-pane--collapsed {
+  max-width: 100%;
 }
 
 .editor-wrapper {
@@ -828,7 +835,8 @@ async function handleSave() {
 .right-pane {
   position: relative;
   flex: 1 1 auto;
-  min-width: 300px;
+  min-width: 32%;
+  max-width: 72%;
   transition: min-width 0.15s ease, flex-basis 0.15s ease;
 }
 
@@ -860,8 +868,6 @@ async function handleSave() {
 }
 
 /* ── Tabs: make the whole chain fill available height so the scroll ── */
-/* region reaches the bottom of the panel instead of leaving blank   */
-/* space underneath it on taller screens.                            */
 .right-pane-tabs {
   flex: 1;
   min-height: 0;

--- a/src/components/InstanceEditorDialog.vue
+++ b/src/components/InstanceEditorDialog.vue
@@ -703,6 +703,16 @@ async function handleCancel() {
   emit('update:modelValue', false)
 }
 
+async function handleMathOverwrite() {
+  return confirm({
+    header: 'Overwrite Math?',
+    message: 'You are about to overwrite an existing math definition. Are you sure you want to proceed?',
+    severity: 'warning',
+    acceptLabel: 'Proceed',
+    rejectLabel: 'Cancel',
+  })
+}
+
 // ── Save Processing ──────────────────────────────────────────────────────────
 async function handleSave() {
   // 1. Validate Instance Name
@@ -754,13 +764,9 @@ async function handleSave() {
     const newComponentName = componentNames[0].trim()
     newMathRef = `${componentFile.value}:${newComponentName}`
 
-    if (newMathRef !== props.mathRef && store.availableMath.has(newMathRef)) {
-      await alert({
-        header: 'Name Conflict',
-        message: 'Name clash detected. Please rename the component in the editor before saving.',
-        severity: 'error',
-      })
-      return
+    if (newMathRef === props.mathRef && store.availableMath.has(newMathRef)) {
+      const overwrite = await handleMathOverwrite()
+      if (!overwrite) return
     }
     store.addMath(newMathRef, currentModel.value)
   }

--- a/src/components/InstanceEditorDialog.vue
+++ b/src/components/InstanceEditorDialog.vue
@@ -5,6 +5,7 @@
     :header="dialogTitle"
     :dismissableMask="!loading"
     :style="{ width: '95vw', maxWidth: '1680px', height: '90vh', maxHeight: '960px' }"
+    :breakpoints="{ '1200px': '95vw', '576px': '100vw' }"
     class="module-editor-dialog"
     @update:visible="onDialogVisibleChange"
   >
@@ -13,7 +14,13 @@
       <span>Loading instance data...</span>
     </div>
 
-    <div v-else class="editor-grid" ref="editorGridRef" :class="{ 'is-dragging': dragging }">
+    <div
+      v-else
+      class="editor-grid"
+      ref="editorGridRef"
+      :class="{ 'is-dragging': dragging, 'is-suppressed': isScreenTooSmall }"
+      :inert="isScreenTooSmall"
+    >
       <!-- LEFT COLUMN: CellML Text Editor -->
       <div class="pane left-pane" :style="leftPaneStyle" :class="{ 'left-pane--collapsed': rightCollapsed }">
         <div class="editor-wrapper">
@@ -150,7 +157,7 @@
                   >
                     <Column selectionMode="multiple" headerStyle="width: 2.2rem" />
                     <Column field="name" bodyClass="small-text-col" header="Name" sortable style="min-width: 120px" />
-                    <Column field="value" header="Value" sortable style="min-width: 120px">
+                    <Column field="value" header="Value" sortable style="width: 120px">
                       <template #body="slotProps">
                         <InputText
                           v-if="isEditableVariableType(slotProps.data.type)"
@@ -163,7 +170,7 @@
                       </template>
                     </Column>
                     <Column field="units" bodyClass="small-text-col" header="Units" sortable style="min-width: 110px" />
-                    <Column field="type" header="Type" sortable style="min-width: 120px">
+                    <Column field="type" header="Type" sortable style="width: 100px">
                       <template #body="slotProps">
                         <Select
                           v-model="slotProps.data.type"
@@ -197,7 +204,19 @@
                     scrollHeight="flex"
                     tableStyle="min-width: 580px"
                   >
-                    <Column header="Type" style="min-width: 90px">
+                    <Column header="" style="width: 25px">
+                      <template #body="slotProps">
+                        <Button
+                          icon="pi pi-trash"
+                          severity="danger"
+                          rounded
+                          text
+                          size="small"
+                          @click="deletePort(editablePorts.indexOf(slotProps.data))"
+                        />
+                      </template>
+                    </Column>
+                    <Column header="Type" style="width: 3cap">
                       <template #body="slotProps">
                         <Select
                           v-model="slotProps.data.portType"
@@ -256,19 +275,6 @@
                         </div>
                       </template>
                     </Column>
-
-                    <Column header="" style="width: 56px; min-width: 56px">
-                      <template #body="slotProps">
-                        <Button
-                          icon="pi pi-trash"
-                          severity="danger"
-                          rounded
-                          text
-                          size="small"
-                          @click="deletePort(editablePorts.indexOf(slotProps.data))"
-                        />
-                      </template>
-                    </Column>
                   </DataTable>
                 </div>
                 <div v-else class="empty-state">No ports defined for this instance.</div>
@@ -279,9 +285,43 @@
       </div>
     </div>
 
+    <!-- OVERLAY: shown when the browser window is too narrow. The editor grid above
+         stays mounted the whole time (CodeMirror + DataTables are expensive to
+         tear down and rebuild), so this is purely a CSS-driven cover, not a
+         v-if swap. -->
+    <Transition name="resize-warning">
+      <div v-if="isScreenTooSmall" class="resize-warning-overlay">
+        <div class="resize-warning-card">
+          <div class="resize-warning-icon">
+            <i class="pi pi-angle-double-left resize-warning-arrow resize-warning-arrow--left"></i>
+            <i class="pi pi-desktop resize-warning-window"></i>
+            <i class="pi pi-angle-double-right resize-warning-arrow resize-warning-arrow--right"></i>
+          </div>
+          <h3 class="resize-warning-title">More room needed</h3>
+          <p class="resize-warning-copy">
+            Widen your browser window to keep editing — the parameter and port panels
+            need a bit more horizontal space to display properly.
+          </p>
+          <div
+            class="resize-warning-meter"
+            role="img"
+            :aria-label="`Window is ${currentWidth} pixels wide, ${MIN_REQUIRED_WIDTH} needed`"
+          >
+            <div class="resize-warning-meter-track">
+              <div class="resize-warning-meter-fill" :style="{ width: widthProgressPercent + '%' }"></div>
+            </div>
+            <div class="resize-warning-meter-labels">
+              <span>{{ currentWidth }}px</span>
+              <span>{{ MIN_REQUIRED_WIDTH }}px needed</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Transition>
+
     <!-- DIALOG FOOTER -->
     <template #footer>
-      <div class="dialog-footer">
+      <div class="dialog-footer" v-if="!loading && !isScreenTooSmall">
         <div
           v-if="siblingCount > 0"
           class="apply-all-checkbox"
@@ -304,7 +344,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onBeforeUnmount } from 'vue'
+import { ref, computed, watch, onBeforeUnmount, onMounted, onUnmounted } from 'vue'
 import { useVueFlow } from '@vue-flow/core'
 
 import Button from 'primevue/button'
@@ -386,7 +426,8 @@ const editablePorts = ref([])
 const SPLIT_STORAGE_KEY = 'instanceEditorDialog.leftPanePercent'
 const DEFAULT_LEFT_PERCENT = 48
 const MIN_LEFT_PERCENT = 32
-const MAX_LEFT_PERCENT = 72
+const MAX_LEFT_PERCENT = 60
+const MIN_REQUIRED_WIDTH = 1200;
 
 function loadStoredSplit() {
   try {
@@ -467,6 +508,57 @@ function toggleRightPanel() {
 
 onBeforeUnmount(() => {
   window.removeEventListener('pointermove', onResizeMove)
+})
+
+// ── Too-small-window overlay ────────────────────────────────────────────────
+const RESIZE_MEDIA_QUERY = `(min-width: ${MIN_REQUIRED_WIDTH}px)`
+const isScreenTooSmall = ref(false)
+const currentWidth = ref(window.innerWidth)
+
+const widthProgressPercent = computed(() =>
+  Math.min(100, Math.round((currentWidth.value / MIN_REQUIRED_WIDTH) * 100))
+)
+
+let resizeMql = null
+let widthRafId = null
+
+function updateCurrentWidth() {
+  currentWidth.value = window.innerWidth
+  widthRafId = null
+}
+
+function scheduleWidthUpdate() {
+  if (widthRafId !== null) return
+  widthRafId = requestAnimationFrame(updateCurrentWidth)
+}
+
+function handleMediaChange(event) {
+  isScreenTooSmall.value = !event.matches
+}
+
+watch(isScreenTooSmall, (tooSmall) => {
+  if (tooSmall) {
+    updateCurrentWidth()
+    window.addEventListener('resize', scheduleWidthUpdate, { passive: true })
+  } else {
+    window.removeEventListener('resize', scheduleWidthUpdate)
+    if (widthRafId !== null) {
+      cancelAnimationFrame(widthRafId)
+      widthRafId = null
+    }
+  }
+})
+
+onMounted(() => {
+  resizeMql = window.matchMedia(RESIZE_MEDIA_QUERY)
+  isScreenTooSmall.value = !resizeMql.matches
+  resizeMql.addEventListener('change', handleMediaChange)
+})
+
+onUnmounted(() => {
+  resizeMql?.removeEventListener('change', handleMediaChange)
+  window.removeEventListener('resize', scheduleWidthUpdate)
+  if (widthRafId !== null) cancelAnimationFrame(widthRafId)
 })
 
 // ── Computed ─────────────────────────────────────────────────────────────────
@@ -706,6 +798,7 @@ async function handleSave() {
 }
 
 .module-editor-dialog :deep(.p-dialog-content) {
+  position: relative !important;
   display: flex !important;
   flex-direction: column !important;
   overflow: hidden !important;
@@ -727,11 +820,18 @@ async function handleSave() {
   min-height: 0;
   max-height: 100%;
   max-width: 100%;
+  transition: filter 0.2s ease, opacity 0.2s ease;
 }
 
 .editor-grid.is-dragging {
   cursor: col-resize;
   user-select: none;
+}
+
+.editor-grid.is-suppressed {
+  pointer-events: none;
+  opacity: 0.4;
+  filter: blur(2px) saturate(0.7);
 }
 
 .pane {
@@ -748,7 +848,7 @@ async function handleSave() {
 
 .left-pane {
   min-width: 38%;
-  max-width: 67%;
+  max-width: 55%;
 }
 
 .left-pane--collapsed {
@@ -1075,6 +1175,136 @@ async function handleSave() {
   justify-content: center;
   height: 400px;
   gap: 12px;
+}
+
+/* ── Resize warning overlay ── */
+.resize-warning-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(15, 15, 20, 0.45);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
+.resize-warning-card {
+  width: min(420px, 100%);
+  text-align: center;
+  padding: 32px 28px;
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 12px;
+  background: var(--p-content-background);
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.18);
+}
+
+.resize-warning-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  margin-bottom: 20px;
+}
+
+.resize-warning-window {
+  font-size: 2.5rem;
+  color: var(--p-primary-color);
+}
+
+.resize-warning-arrow {
+  font-size: 1.375rem;
+  color: var(--p-primary-color);
+  opacity: 0.45;
+  animation-duration: 1.6s;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+}
+
+.resize-warning-arrow--left {
+  animation-name: resize-warning-pulse-left;
+}
+
+.resize-warning-arrow--right {
+  animation-name: resize-warning-pulse-right;
+  animation-delay: 0.1s;
+}
+
+@keyframes resize-warning-pulse-left {
+  0%, 100% { transform: translateX(0); opacity: 0.4; }
+  50% { transform: translateX(-6px); opacity: 1; }
+}
+
+@keyframes resize-warning-pulse-right {
+  0%, 100% { transform: translateX(0); opacity: 0.4; }
+  50% { transform: translateX(6px); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .resize-warning-arrow {
+    animation: none;
+    opacity: 0.7;
+  }
+}
+
+.resize-warning-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+
+.resize-warning-copy {
+  color: var(--p-text-muted-color);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  margin: 0 0 22px;
+}
+
+.resize-warning-meter-track {
+  height: 6px;
+  border-radius: 999px;
+  background: var(--p-content-hover-background, rgba(0, 0, 0, 0.08));
+  overflow: hidden;
+}
+
+.resize-warning-meter-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--p-primary-color);
+  transition: width 0.15s ease-out;
+}
+
+.resize-warning-meter-labels {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 6px;
+  font-size: 0.75rem;
+  color: var(--p-text-muted-color);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Transition: overlay fades, card fades + scales in slightly */
+.resize-warning-enter-active,
+.resize-warning-leave-active {
+  transition: opacity 0.18s ease;
+}
+
+.resize-warning-enter-from,
+.resize-warning-leave-to {
+  opacity: 0;
+}
+
+.resize-warning-enter-active .resize-warning-card,
+.resize-warning-leave-active .resize-warning-card {
+  transition: transform 0.18s ease, opacity 0.18s ease;
+}
+
+.resize-warning-enter-from .resize-warning-card,
+.resize-warning-leave-to .resize-warning-card {
+  transform: scale(0.96) translateY(6px);
+  opacity: 0;
 }
 
 @media (max-width: 900px) {

--- a/src/components/InstanceEditorDialog.vue
+++ b/src/components/InstanceEditorDialog.vue
@@ -584,9 +584,9 @@ const siblings = computed(() => {
 
 const siblingCount = computed(() => siblings.value.length)
 
-const isDirty = computed(() => {
-  return !areModelsEquivalent(originalModel.value, currentModel.value)
-})
+const isDirty = computed(() =>
+  !areModelsEquivalent(originalModel.value, currentModel.value)
+)
 
 const filteredParameterRows = computed(() => {
   if (!searchQuery.value.trim()) return parameterRows.value
@@ -645,6 +645,7 @@ function handleCodeUpdate(newCode) {
 }
 
 function handleEditorReady(canonicalMath) {
+  void isDirty.value
   currentModel.value = canonicalMath
   originalModel.value = canonicalMath
 }

--- a/src/components/InstanceEditorDialog.vue
+++ b/src/components/InstanceEditorDialog.vue
@@ -715,7 +715,7 @@ async function handleCancel() {
 async function handleMathOverwrite() {
   return confirm({
     header: 'Overwrite Math?',
-    message: 'You are about to overwrite an existing math definition. Are you sure you want to proceed?',
+    message: `You are about to overwrite an existing math definition. This will affect ${siblingCount.value} other instances. Are you sure you want to proceed?`,
     severity: 'warning',
     acceptLabel: 'Proceed',
     rejectLabel: 'Cancel',

--- a/src/components/InstanceEditorDialog.vue
+++ b/src/components/InstanceEditorDialog.vue
@@ -2,13 +2,24 @@
   <Dialog
     :visible="modelValue"
     modal
-    :header="dialogTitle"
     :dismissableMask="!loading"
+    :draggable="false"
     :style="{ width: '95vw', maxWidth: '1680px', height: '90vh', maxHeight: '960px' }"
-    :breakpoints="{ '1200px': '95vw', '576px': '100vw' }"
     class="module-editor-dialog"
     @update:visible="onDialogVisibleChange"
   >
+    <template #header>
+      <div class="custom-dialog-header">
+        <span class="header-prefix">Editing: </span>
+        <InputText 
+          v-model="editableName" 
+          placeholder="Enter instance name..." 
+          size="small"
+          class="header-input"
+        />
+        <span class="header-suffix">({{ componentName }} - {{ componentFile }})</span>
+      </div>
+    </template>
     <div v-if="loading" class="loading-overlay">
       <ProgressSpinner style="width: 44px; height: 44px" strokeWidth="4" />
       <span>Loading instance data...</span>
@@ -285,10 +296,7 @@
       </div>
     </div>
 
-    <!-- OVERLAY: shown when the browser window is too narrow. The editor grid above
-         stays mounted the whole time (CodeMirror + DataTables are expensive to
-         tear down and rebuild), so this is purely a CSS-driven cover, not a
-         v-if swap. -->
+    <!-- OVERLAY:  -->
     <Transition name="resize-warning">
       <div v-if="isScreenTooSmall" class="resize-warning-overlay">
         <div class="resize-warning-card">
@@ -424,10 +432,10 @@ const editablePorts = ref([])
 
 // ── Split / Collapse State ──────────────────────────────────────────────────
 const SPLIT_STORAGE_KEY = 'instanceEditorDialog.leftPanePercent'
-const DEFAULT_LEFT_PERCENT = 48
+const DEFAULT_LEFT_PERCENT = 55
 const MIN_LEFT_PERCENT = 32
 const MAX_LEFT_PERCENT = 60
-const MIN_REQUIRED_WIDTH = 1200;
+const MIN_REQUIRED_WIDTH = 1000;
 
 function loadStoredSplit() {
   try {
@@ -619,8 +627,8 @@ watch(
       try {
         if (props.mathRef) {
           const math = store.availableMath.get(props.mathRef)
-          currentModel.value = math || ''
-          originalModel.value = math || ''
+          currentModel.value = math
+          originalModel.value = math
         }
       } catch (e) {
         console.error('Failed to load CellML source', e)
@@ -796,6 +804,31 @@ async function handleSave() {
 </script>
 
 <style scoped>
+.custom-dialog-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 1.125rem;
+  font-weight: 600;
+  width: 100%;
+}
+
+.header-prefix {
+  color: var(--p-text-color);
+}
+
+.header-input {
+  width: 300px;
+  font-size: 1rem;
+  font-weight: normal;
+}
+
+.header-suffix {
+  color: var(--p-text-muted-color);
+  font-size: 0.9rem;
+  font-weight: normal;
+}
+
 .module-editor-dialog {
   display: flex;
   flex-direction: column;

--- a/src/components/InstanceEditorDialog.vue
+++ b/src/components/InstanceEditorDialog.vue
@@ -1,0 +1,701 @@
+<template>
+  <Dialog
+    :visible="modelValue"
+    modal
+    :header="dialogTitle"
+    :dismissableMask="!loading"
+    :style="{ width: '92vw', maxWidth: '1500px' }"
+    class="module-editor-dialog"
+    @update:visible="onDialogVisibleChange"
+  >
+    <div v-if="loading" class="loading-overlay">
+      <ProgressSpinner style="width: 44px; height: 44px" strokeWidth="4" />
+      <span>Loading instance data...</span>
+    </div>
+
+    <div v-else class="editor-grid">
+      <!-- LEFT COLUMN: CellML Text Editor -->
+      <div class="pane left-pane">
+        <div class="editor-wrapper">
+          <CellMLTextEditor
+            :key="mathRef"
+            :model-value="currentModel"
+            @update:code="handleCodeUpdate"
+            @ready="handleEditorReady"
+            @save="handleSave"
+          />
+        </div>
+      </div>
+
+      <!-- RIGHT COLUMN: Parameter & Port Tabs -->
+      <div class="pane right-pane">
+        <Tabs v-model:value="activeTab">
+          <TabList>
+            <Tab value="parameters">
+              <i class="pi pi-sliders-h tab-icon"></i>
+              Parameters ({{ parameterRows.length }})
+            </Tab>
+            <Tab value="ports">
+              <i class="pi pi-pencil tab-icon"></i>
+              Ports ({{ editablePorts.length }})
+            </Tab>
+          </TabList>
+
+          <TabPanels class="tab-panels-container">
+            <!-- TAB 1: PARAMETER EDITOR -->
+            <TabPanel value="parameters">
+              <div class="toolbar-container">
+                <div class="search-group">
+                  <div class="search-input-wrapper">
+                    <InputText
+                      v-model="searchQuery"
+                      size="small"
+                      :placeholder="`Search by ${searchColumn}...`"
+                      class="search-input"
+                    />
+                    <Button
+                      v-if="searchQuery"
+                      icon="pi pi-times"
+                      text
+                      rounded
+                      severity="secondary"
+                      size="small"
+                      class="clear-search-btn"
+                      @click="searchQuery = ''"
+                    />
+                  </div>
+                  <Select
+                    v-model="searchColumn"
+                    :options="searchColumnOptions"
+                    optionLabel="label"
+                    optionValue="value"
+                    size="small"
+                    class="search-column"
+                  />
+                </div>
+
+                <div class="bulk-controls">
+                  <span class="bulk-label">Bulk Type:</span>
+                  <Select
+                    v-model="bulkTypeValue"
+                    size="small"
+                    :options="PARAMETER_TYPE_OPTIONS"
+                    optionLabel="label"
+                    optionValue="value"
+                    placeholder="Select type..."
+                    class="bulk-select"
+                  />
+                  <Button
+                    size="small"
+                    :disabled="selectedRows.length === 0"
+                    @click="applyBulkType"
+                  >
+                    Apply ({{ selectedRows.length }})
+                  </Button>
+                </div>
+              </div>
+
+              <DataTable
+                ref="parametersTable"
+                v-model:selection="selectedRows"
+                :value="filteredParameterRows"
+                dataKey="name"
+                scrollable
+                scrollHeight="480px"
+                tableStyle="min-width: 100%"
+                :sortField="sortField"
+                :sortOrder="sortOrder"
+                class="p-datatable-sm parameters-table"
+                @sort="handleSortChange"
+              >
+                <Column selectionMode="multiple" headerStyle="width: 2.2rem" />
+                <Column field="name" bodyClass="small-text-col" header="Name" sortable style="min-width: 140px" />
+                <Column field="value" header="Value" sortable style="min-width: 150px">
+                  <template #body="slotProps">
+                    <InputText
+                      v-if="isEditableVariableType(slotProps.data.type)"
+                      v-model="slotProps.data.value"
+                      size="small"
+                      placeholder="Enter value..."
+                      class="w-full"
+                    />
+                    <span v-else class="text-muted">-</span>
+                  </template>
+                </Column>
+                <Column field="units" bodyClass="small-text-col" header="Units" sortable style="min-width: 100px" />
+                <Column field="type" header="Type" sortable style="min-width: 180px">
+                  <template #body="slotProps">
+                    <Select
+                      v-model="slotProps.data.type"
+                      :options="PARAMETER_TYPE_OPTIONS"
+                      optionLabel="label"
+                      optionValue="value"
+                      size="small"
+                      class="w-full"
+                    />
+                  </template>
+                </Column>
+              </DataTable>
+            </TabPanel>
+
+            <!-- TAB 2: PORT EDITOR -->
+            <TabPanel value="ports">
+              <div class="ports-tab-body">
+                <div class="ports-header">
+                  <label class="form-label">Port Definitions</label>
+                  <Button icon="pi pi-plus" label="Add Port" severity="success" size="small" rounded outlined @click="addPort" />
+                </div>
+
+                <div v-if="editablePorts.length" class="mt-2 overflow-x-auto">
+                  <DataTable :value="editablePorts" size="small" stripedRows scrollable scrollHeight="380px">
+                    <Column header="Type" style="width: 110px">
+                      <template #body="slotProps">
+                        <Select
+                          v-model="slotProps.data.portType"
+                          :options="PORT_TYPE_OPTIONS"
+                          optionLabel="label"
+                          optionValue="value"
+                          size="small"
+                          class="w-full"
+                        />
+                      </template>
+                    </Column>
+
+                    <Column header="Label" style="width: 160px">
+                      <template #body="slotProps">
+                        <InputText v-model="slotProps.data.label" placeholder="Enter label" size="small" class="w-full" />
+                      </template>
+                    </Column>
+
+                    <Column header="Variable(s)" style="min-width: 160px">
+                      <template #body="slotProps">
+                        <Select
+                          v-model="slotProps.data.variables"
+                          :options="variables"
+                          optionLabel="name"
+                          optionValue="name"
+                          multiple
+                          size="small"
+                          placeholder="Select variables"
+                          class="w-full"
+                        />
+                      </template>
+                    </Column>
+
+                    <Column header="Multiport" style="width: 130px">
+                      <template #body="slotProps">
+                        <div class="flex flex-col gap-1">
+                          <Select
+                            v-model="slotProps.data.multiportType"
+                            :options="MULTIPORT_OPTIONS"
+                            optionLabel="label"
+                            optionValue="value"
+                            size="small"
+                            placeholder="Select"
+                            class="w-full"
+                          />
+                          <div v-if="slotProps.data.multiportType === 'Multiply'" class="flex items-center gap-1">
+                            <span class="multiply-prefix">&times;</span>
+                            <InputNumber
+                              v-model="slotProps.data.multiplyFactor"
+                              :showButtons="false"
+                              size="small"
+                              placeholder="1"
+                              class="w-full"
+                            />
+                          </div>
+                        </div>
+                      </template>
+                    </Column>
+
+                    <Column header="" style="width: 50px">
+                      <template #body="slotProps">
+                        <Button
+                          icon="pi pi-trash"
+                          severity="danger"
+                          rounded
+                          text
+                          size="small"
+                          @click="deletePort(editablePorts.indexOf(slotProps.data))"
+                        />
+                      </template>
+                    </Column>
+                  </DataTable>
+                </div>
+                <div v-else class="empty-state">No ports defined for this instance.</div>
+              </div>
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+      </div>
+    </div>
+
+    <!-- DIALOG FOOTER -->
+    <template #footer>
+      <div class="dialog-footer">
+        <div
+          v-if="siblingCount > 0"
+          class="apply-all-checkbox"
+          :title="`Also update ${siblingCount} other node${
+            siblingCount !== 1 ? 's' : ''
+          } using ${componentName} from ${componentFile}`"
+        >
+          <Checkbox v-model="applyToAll" binary inputId="applyToAll" />
+          <label for="applyToAll">Apply CellML changes to all instances</label>
+          <Tag severity="info" :value="String(siblingCount + 1)" />
+        </div>
+
+        <div class="footer-buttons">
+          <Button label="Cancel" severity="secondary" text @click="handleCancel" />
+          <Button label="Save All Changes" severity="primary" @click="handleSave" />
+        </div>
+      </div>
+    </template>
+  </Dialog>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { useVueFlow } from '@vue-flow/core'
+
+import Button from 'primevue/button'
+import Checkbox from 'primevue/checkbox'
+import Column from 'primevue/column'
+import DataTable from 'primevue/datatable'
+import Dialog from 'primevue/dialog'
+import Divider from 'primevue/divider'
+import InputNumber from 'primevue/inputnumber'
+import InputText from 'primevue/inputtext'
+import ProgressSpinner from 'primevue/progressspinner'
+import Select from 'primevue/select'
+import Tab from 'primevue/tab'
+import TabList from 'primevue/tablist'
+import TabPanel from 'primevue/tabpanel'
+import TabPanels from 'primevue/tabpanels'
+import Tabs from 'primevue/tabs'
+import Tag from 'primevue/tag'
+
+import CellMLTextEditor from './CellMLTextEditor.vue'
+import { useLibraryStore } from '../stores/libraryStore'
+import { useGtm } from '../composables/useGtm'
+import { useConfirmDialog } from '../composables/useConfirmDialog'
+
+import { PARAMETER_TYPE_OPTIONS, PORT_TYPE_OPTIONS, MULTIPORT_OPTIONS } from '../utils/constants'
+import { isEditableVariableType, isEmpty } from '../utils/variables'
+import { sanitiseName } from '../utils/nodes'
+import { detachReactivity } from '../utils/reactivity'
+import { notify } from '../utils/notify'
+import { getModelComponentNames, areModelsEquivalent } from '../utils/cellml'
+
+const props = defineProps({
+  modelValue: { type: Boolean, default: false },
+  id: { type: String, required: true },
+  initialName: { type: String, default: '' },
+  mathRef: { type: String, required: true },
+  variables: { type: Array, default: () => [] },
+  initialPorts: { type: Array, default: () => [] },
+  existingNames: { type: Array, default: () => [] },
+  defaultTab: { type: String, default: 'parameters' }, // 'parameters' or 'ports'
+})
+
+const emit = defineEmits(['update:modelValue', 'save'])
+
+const store = useLibraryStore()
+const { trackEvent } = useGtm()
+const { nodes } = useVueFlow()
+const { alert, confirm } = useConfirmDialog()
+
+// ── State ────────────────────────────────────────────────────────────────────
+const loading = ref(false)
+const activeTab = ref('parameters')
+
+// CellML State
+const currentModel = ref('')
+const originalModel = ref('')
+const applyToAll = ref(false)
+
+// Parameter State
+const parameterRows = ref([])
+const selectedRows = ref([])
+const searchQuery = ref('')
+const searchColumn = ref('name')
+const searchColumnOptions = [
+  { label: 'Name', value: 'name' },
+  { label: 'Units', value: 'units' },
+  { label: 'Type', value: 'type' },
+]
+const bulkTypeValue = ref('')
+const sortField = ref('name')
+const sortOrder = ref(1)
+
+// Port & Instance State
+const editableName = ref('')
+const editablePorts = ref([])
+
+// ── Computed ─────────────────────────────────────────────────────────────────
+const componentFile = computed(() => props.mathRef?.split(':')[0])
+const componentName = computed(() => props.mathRef?.split(':')[1])
+
+const dialogTitle = computed(() => {
+  return `Editing: ${editableName.value || props.initialName} (${componentName.value} - ${componentFile.value})`
+})
+
+const siblings = computed(() => {
+  if (!componentName.value || !componentFile.value) return []
+  return nodes.value.filter((n) => n.id !== props.id && n.data?.mathRef === props.mathRef).map((n) => n.id)
+})
+
+const siblingCount = computed(() => siblings.value.length)
+
+const isDirty = computed(() => {
+  return !areModelsEquivalent(originalModel.value, currentModel.value)
+})
+
+const filteredParameterRows = computed(() => {
+  if (!searchQuery.value.trim()) return parameterRows.value
+  const query = searchQuery.value.toLowerCase()
+  const columnKey = searchColumn.value
+  return parameterRows.value.filter((row) => String(row[columnKey] || '').toLowerCase().includes(query))
+})
+
+// ── Watchers & Handlers ──────────────────────────────────────────────────────
+watch(
+  () => props.modelValue,
+  async (isOpen) => {
+    if (isOpen) {
+      loading.value = true
+      applyToAll.value = false
+      activeTab.value = props.defaultTab || 'parameters'
+
+      // Load Instance & Port data
+      editableName.value = props.initialName
+      editablePorts.value = detachReactivity(props.initialPorts || [])
+
+      // Load Parameters
+      parameterRows.value = props.variables.map((row) => ({
+        name: row.name,
+        value: row.type === 'global_constant' ? store.getGlobalConstant(row.name)?.value : row.value,
+        units: row.units,
+        type: row.type,
+        access: row.access,
+      }))
+      sortParameterRows('type', 1)
+
+      // Load CellML
+      try {
+        if (props.mathRef) {
+          const math = store.availableMath.get(props.mathRef)
+          currentModel.value = math || ''
+          originalModel.value = math || ''
+        }
+      } catch (e) {
+        console.error('Failed to load CellML source', e)
+      } finally {
+        loading.value = false
+      }
+    }
+  }
+)
+
+function handleCodeUpdate(newCode) {
+  currentModel.value = newCode
+}
+
+function handleEditorReady(canonicalMath) {
+  currentModel.value = canonicalMath
+  originalModel.value = canonicalMath
+}
+
+function sortParameterRows(field = 'type', order = 1) {
+  parameterRows.value.sort((a, b) => {
+    const valA = String(a[field] || '').toLowerCase()
+    const valB = String(b[field] || '').toLowerCase()
+    const result = valA.localeCompare(valB)
+    return result !== 0 ? (order === 1 ? result : -result) : a.name.localeCompare(b.name)
+  })
+}
+
+function handleSortChange(event) {
+  const field = event?.sortField || 'type'
+  const order = event?.sortOrder === -1 ? -1 : 1
+  sortField.value = field
+  sortOrder.value = order
+  sortParameterRows(field, order)
+}
+
+function applyBulkType() {
+  if (!bulkTypeValue.value || selectedRows.value.length === 0) return
+  const targetType = bulkTypeValue.value
+  selectedRows.value.forEach((row) => {
+    row.type = targetType
+  })
+  selectedRows.value = []
+  bulkTypeValue.value = ''
+}
+
+function addPort() {
+  editablePorts.value.push({
+    portType: 'general_ports',
+    variables: [],
+    label: '',
+    multiportType: 'None',
+    multiplyFactor: 1,
+  })
+}
+
+function deletePort(index) {
+  editablePorts.value.splice(index, 1)
+}
+
+const onDialogVisibleChange = (visible) => {
+  if (visible) {
+    emit('update:modelValue', true)
+  } else {
+    handleCancel()
+  }
+}
+
+async function handleCancel() {
+  if (isDirty.value) {
+    const confirmed = await confirm({
+      header: 'Unsaved CellML Changes',
+      message: 'You have modified CellML code. Are you sure you want to discard changes?',
+      severity: 'warning',
+      acceptLabel: 'Discard & Close',
+      rejectLabel: 'Cancel',
+    })
+    if (!confirmed) return
+  }
+  emit('update:modelValue', false)
+}
+
+// ── Save Processing ──────────────────────────────────────────────────────────
+async function handleSave() {
+  // 1. Validate Instance Name
+  if (!editableName.value || !editableName.value.trim()) {
+    notify.error({ message: 'Instance name cannot be empty.' })
+    activeTab.value = 'ports'
+    return
+  }
+  const sanitised = sanitiseName(editableName.value)
+  if (!sanitised) {
+    notify.error({ message: 'Instance name is invalid.' })
+    activeTab.value = 'ports'
+    return
+  }
+  editableName.value = sanitised
+
+  const nameExists = props.existingNames.some((n) => n === editableName.value && n !== props.initialName)
+  if (nameExists) {
+    notify.error({ message: 'An instance with this name already exists.' })
+    activeTab.value = 'ports'
+    return
+  }
+
+  // 2. Validate Ports
+  const finalPorts = editablePorts.value.filter((p) => p.variables?.length && p.label?.trim())
+  const invalidFactor = finalPorts.find((p) => p.multiportType === 'Multiply' && isEmpty(p.multiplyFactor))
+  if (invalidFactor) {
+    notify.error({ message: `Port "${invalidFactor.label}" has Multiply selected but missing scale factor.` })
+    activeTab.value = 'ports'
+    return
+  }
+
+  // 3. Process Global Constants from Parameters
+  parameterRows.value.forEach((row) => {
+    if (row.type === 'global_constant') {
+      store.assignGlobalConstant(row.name, row.value, row.units, row.data_reference)
+    }
+  })
+
+  // 4. Process CellML Source Changes
+  let newMathRef = props.mathRef
+  if (isDirty.value) {
+    const componentNames = getModelComponentNames(currentModel.value)
+    if (!componentNames || componentNames.length === 0) {
+      window.alert('Could not find a valid component name in the model.')
+      return
+    }
+    const newComponentName = componentNames[0].trim()
+    newMathRef = `${componentFile.value}:${newComponentName}`
+
+    if (newMathRef !== props.mathRef && store.availableMath.has(newMathRef)) {
+      await alert({
+        header: 'Name Conflict',
+        message: 'Name clash detected. Please rename the component in the editor before saving.',
+        severity: 'error',
+      })
+      return
+    }
+    store.addMath(newMathRef, currentModel.value)
+  }
+
+  const updateAll = (siblingCount.value > 0 && applyToAll.value) || siblingCount.value === 0
+
+  trackEvent('editor_action', {
+    category: 'Editor',
+    action: 'save_unified_module',
+    label: editableName.value,
+  })
+
+  // Emit consolidated payload to parent workspace
+  emit('save', {
+    id: props.id,
+    name: editableName.value,
+    mathRef: newMathRef,
+    math: currentModel.value,
+    variables: parameterRows.value,
+    ports: finalPorts,
+    updateAll,
+    siblings: updateAll ? siblings.value : undefined,
+  })
+
+  emit('update:modelValue', false)
+}
+</script>
+
+<style scoped>
+.editor-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  height: 72vh;
+  min-height: 550px;
+}
+
+.pane {
+  display: flex;
+  flex-direction: column;
+  background: var(--p-content-background);
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 8px;
+  padding: 12px;
+  overflow: hidden;
+}
+
+.pane-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  margin-bottom: 8px;
+  color: var(--p-text-color);
+}
+
+.editor-wrapper {
+  flex: 1;
+  min-height: 0;
+}
+
+.tab-icon {
+  margin-right: 6px;
+  font-size: 0.85rem;
+}
+
+.tab-panels-container {
+  flex: 1;
+  overflow-y: auto;
+  padding-top: 12px;
+}
+
+/* Parameters Tab Styles */
+.toolbar-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 10px;
+  margin-bottom: 12px;
+  background-color: var(--p-content-hover-background, rgba(0, 0, 0, 0.02));
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 6px;
+}
+
+.search-group, .bulk-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.search-input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.clear-search-btn {
+  position: absolute;
+  right: 2px;
+  width: 1.25rem !important;
+  height: 1.25rem !important;
+}
+
+.search-column { width: 90px; }
+.bulk-select { width: 140px; }
+.bulk-label { font-size: 0.8rem; color: var(--p-text-muted-color); }
+
+/* Ports Tab Styles */
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.form-label {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.ports-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.empty-state {
+  color: var(--p-text-muted-color);
+  font-size: 0.85rem;
+  margin-top: 16px;
+  text-align: center;
+}
+
+.multiply-prefix {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--p-text-muted-color);
+}
+
+.w-full { width: 100%; }
+.text-muted { color: var(--p-text-muted-color); }
+
+/* Footer */
+.dialog-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 16px;
+  width: 100%;
+}
+
+.apply-all-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-right: auto;
+  font-size: 0.85rem;
+}
+
+.footer-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.loading-overlay {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 400px;
+  gap: 12px;
+}
+
+</style>

--- a/src/components/InstanceEditorDialog.vue
+++ b/src/components/InstanceEditorDialog.vue
@@ -4,7 +4,7 @@
     modal
     :header="dialogTitle"
     :dismissableMask="!loading"
-    :style="{ width: '95vw', maxWidth: '1680px' }"
+    :style="{ width: '95vw', maxWidth: '1680px', height: '90vh', maxHeight: '960px' }"
     class="module-editor-dialog"
     @update:visible="onDialogVisibleChange"
   >
@@ -163,7 +163,7 @@
                       </template>
                     </Column>
                     <Column field="units" bodyClass="small-text-col" header="Units" sortable style="min-width: 110px" />
-                    <Column field="type" header="Type" sortable style="min-width: 170px">
+                    <Column field="type" header="Type" sortable style="min-width: 120px">
                       <template #body="slotProps">
                         <Select
                           v-model="slotProps.data.type"
@@ -189,8 +189,15 @@
                 </div>
 
                 <div v-if="editablePorts.length" class="table-flex-wrapper">
-                  <DataTable :value="editablePorts" size="small" stripedRows scrollHeight="flex">
-                    <Column header="Type" style="min-width: 50px">
+                  <DataTable
+                    :value="editablePorts"
+                    size="small"
+                    stripedRows
+                    scrollable
+                    scrollHeight="flex"
+                    tableStyle="min-width: 580px"
+                  >
+                    <Column header="Type" style="min-width: 90px">
                       <template #body="slotProps">
                         <Select
                           v-model="slotProps.data.portType"
@@ -203,13 +210,13 @@
                       </template>
                     </Column>
 
-                    <Column header="Label" style="min-width: 170px">
+                    <Column header="Label" style="min-width: 140px">
                       <template #body="slotProps">
                         <InputText v-model="slotProps.data.label" placeholder="Enter label" size="small" class="w-full" />
                       </template>
                     </Column>
 
-                    <Column header="Variable(s)" style="min-width: 220px">
+                    <Column header="Variable(s)" style="min-width: 180px">
                       <template #body="slotProps">
                         <MultiSelect
                           v-model="slotProps.data.variables"
@@ -224,7 +231,7 @@
                       </template>
                     </Column>
 
-                    <Column header="Multiport" style="min-width: 50px">
+                    <Column header="Multiport" style="min-width: 110px">
                       <template #body="slotProps">
                         <div class="flex flex-col gap-1">
                           <Select
@@ -250,7 +257,7 @@
                       </template>
                     </Column>
 
-                    <Column header="" style="width: 56px">
+                    <Column header="" style="width: 56px; min-width: 56px">
                       <template #body="slotProps">
                         <Button
                           icon="pi pi-trash"
@@ -377,8 +384,8 @@ const editablePorts = ref([])
 
 // ── Split / Collapse State ──────────────────────────────────────────────────
 const SPLIT_STORAGE_KEY = 'instanceEditorDialog.leftPanePercent'
-const DEFAULT_LEFT_PERCENT = 55
-const MIN_LEFT_PERCENT = 40
+const DEFAULT_LEFT_PERCENT = 48
+const MIN_LEFT_PERCENT = 32
 const MAX_LEFT_PERCENT = 72
 
 function loadStoredSplit() {
@@ -593,8 +600,8 @@ const onDialogVisibleChange = (visible) => {
 async function handleCancel() {
   if (isDirty.value) {
     const confirmed = await confirm({
-      header: 'Unsaved CellML Changes',
-      message: 'You have modified CellML code. Are you sure you want to discard changes?',
+      header: 'Unsaved Changes',
+      message: 'Are you sure you want to discard changes?',
       severity: 'warning',
       acceptLabel: 'Discard & Close',
       rejectLabel: 'Cancel',
@@ -690,6 +697,21 @@ async function handleSave() {
 </script>
 
 <style scoped>
+.module-editor-dialog {
+  display: flex !important;
+  flex-direction: column !important;
+  overflow: hidden !important;
+}
+
+.module-editor-dialog :deep(.p-dialog-content) {
+  display: flex !important;
+  flex-direction: column !important;
+  overflow: hidden !important;
+  flex: 1 1 auto !important;
+  min-height: 0 !important;
+  padding-bottom: 16px !important;
+}
+
 /* ── Design tokens (kept local to this dialog for consistent typography) ── */
 .editor-grid {
   --dlg-fs-label: 0.875rem;   /* 14px - field/section labels */
@@ -700,7 +722,9 @@ async function handleSave() {
   display: flex;
   align-items: stretch;
   gap: 0;
-  height: clamp(520px, 78vh, 940px);
+  flex: 1 1 auto;
+  min-height: 0;
+  height: clamp(520px, 69vh, 940px);
 }
 
 .editor-grid.is-dragging {
@@ -727,6 +751,7 @@ async function handleSave() {
 .editor-wrapper {
   flex: 1;
   min-height: 0;
+  overflow: hidden;
 }
 
 /* ── Resize handle between the two panes; also hosts the collapse/expand button ── */
@@ -784,7 +809,7 @@ async function handleSave() {
   cursor: pointer;
   z-index: 3;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
-  opacity: 0;
+  opacity: 0.55;
   transition: opacity 0.15s ease, color 0.15s ease, background-color 0.15s ease;
 }
 
@@ -803,7 +828,7 @@ async function handleSave() {
 .right-pane {
   position: relative;
   flex: 1 1 auto;
-  min-width: 360px;
+  min-width: 300px;
   transition: min-width 0.15s ease, flex-basis 0.15s ease;
 }
 
@@ -885,6 +910,22 @@ async function handleSave() {
   min-height: 0;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
+}
+
+.table-flex-wrapper :deep(.p-datatable) {
+  display: flex !important;
+  flex-direction: column !important;
+  min-height: 0 !important;
+  height: 100% !important;
+  overflow: hidden !important;
+}
+
+.table-flex-wrapper :deep(.p-datatable-table-container),
+.table-flex-wrapper :deep(.p-datatable-wrapper) {
+  min-height: 0 !important;
+  flex: 1 1 auto !important;
+  overflow-y: auto !important;
 }
 
 .tab-icon {
@@ -895,11 +936,9 @@ async function handleSave() {
 /* Parameters Tab Styles */
 .toolbar-container {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
   gap: 8px;
-  padding: 6px 10px;
+  padding: 8px 10px;
   margin-bottom: 12px;
   background-color: var(--p-content-hover-background, rgba(0, 0, 0, 0.02));
   border: 1px solid var(--p-content-border-color);
@@ -909,7 +948,10 @@ async function handleSave() {
 .search-group, .bulk-controls {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
+}
+
+.search-group {
   flex-wrap: wrap;
 }
 
@@ -917,6 +959,12 @@ async function handleSave() {
   position: relative;
   display: flex;
   align-items: center;
+  flex: 1 1 160px;
+  min-width: 120px;
+}
+
+.search-input-wrapper :deep(.p-inputtext) {
+  width: 100%;
 }
 
 .clear-search-btn {
@@ -926,7 +974,17 @@ async function handleSave() {
   height: 1.25rem !important;
 }
 
-.search-column { width: 130px; }
+.bulk-controls {
+  padding-top: 8px;
+  border-top: 1px solid var(--p-content-border-color);
+  flex-wrap: wrap;
+}
+
+.bulk-controls .bulk-select {
+  margin-right: auto;
+}
+
+.search-column { width: 130px; flex: 0 0 auto; }
 .bulk-select { width: 180px; }
 .bulk-label { font-size: var(--dlg-fs-small); color: var(--p-text-muted-color); white-space: nowrap; }
 
@@ -1016,8 +1074,6 @@ async function handleSave() {
 @media (max-width: 900px) {
   .editor-grid {
     flex-direction: column;
-    height: auto;
-    max-height: 78vh;
   }
 
   .left-pane {

--- a/src/components/InstanceEditorDialog.vue
+++ b/src/components/InstanceEditorDialog.vue
@@ -4,7 +4,7 @@
     modal
     :header="dialogTitle"
     :dismissableMask="!loading"
-    :style="{ width: '92vw', maxWidth: '1500px' }"
+    :style="{ width: '95vw', maxWidth: '1680px' }"
     class="module-editor-dialog"
     @update:visible="onDialogVisibleChange"
   >
@@ -13,9 +13,9 @@
       <span>Loading instance data...</span>
     </div>
 
-    <div v-else class="editor-grid">
+    <div v-else class="editor-grid" ref="editorGridRef" :class="{ 'is-dragging': dragging }">
       <!-- LEFT COLUMN: CellML Text Editor -->
-      <div class="pane left-pane">
+      <div class="pane left-pane" :style="leftPaneStyle">
         <div class="editor-wrapper">
           <CellMLTextEditor
             :key="mathRef"
@@ -27,9 +27,47 @@
         </div>
       </div>
 
+      <!-- RESIZE HANDLE (also carries the collapse/expand control) -->
+      <div
+        class="resizer"
+        :class="{ 'resizer--collapsed': rightCollapsed }"
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize editor and parameter panels"
+        tabindex="0"
+        @pointerdown="startResize"
+        @dblclick="resetSplit"
+        @keydown.left.prevent="nudgeSplit(-2)"
+        @keydown.right.prevent="nudgeSplit(2)"
+      >
+        <div class="resizer-grip"></div>
+        <button
+          type="button"
+          class="resizer-toggle"
+          :title="rightCollapsed ? 'Expand parameter/port panel' : 'Collapse parameter/port panel'"
+          :aria-label="rightCollapsed ? 'Expand panel' : 'Collapse panel'"
+          @pointerdown.stop
+          @click.stop="toggleRightPanel"
+        >
+          <i :class="rightCollapsed ? 'pi pi-angle-left' : 'pi pi-angle-right'"></i>
+        </button>
+      </div>
+
       <!-- RIGHT COLUMN: Parameter & Port Tabs -->
-      <div class="pane right-pane">
-        <Tabs v-model:value="activeTab">
+      <div class="pane right-pane" :class="{ 'right-pane--collapsed': rightCollapsed }">
+        <!-- Collapsed rail: just a slim strip with a vertical label, click to expand -->
+        <button
+          v-if="rightCollapsed"
+          type="button"
+          class="collapsed-rail"
+          @click="toggleRightPanel"
+        >
+          <span class="collapsed-rail-label">
+            {{ activeTab === 'parameters' ? `Parameters (${parameterRows.length})` : `Ports (${editablePorts.length})` }}
+          </span>
+        </button>
+
+        <Tabs v-else v-model:value="activeTab" class="right-pane-tabs">
           <TabList>
             <Tab value="parameters">
               <i class="pi pi-sliders-h tab-icon"></i>
@@ -43,112 +81,116 @@
 
           <TabPanels class="tab-panels-container">
             <!-- TAB 1: PARAMETER EDITOR -->
-            <TabPanel value="parameters">
-              <div class="toolbar-container">
-                <div class="search-group">
-                  <div class="search-input-wrapper">
-                    <InputText
-                      v-model="searchQuery"
-                      size="small"
-                      :placeholder="`Search by ${searchColumn}...`"
-                      class="search-input"
-                    />
-                    <Button
-                      v-if="searchQuery"
-                      icon="pi pi-times"
-                      text
-                      rounded
-                      severity="secondary"
-                      size="small"
-                      class="clear-search-btn"
-                      @click="searchQuery = ''"
-                    />
-                  </div>
-                  <Select
-                    v-model="searchColumn"
-                    :options="searchColumnOptions"
-                    optionLabel="label"
-                    optionValue="value"
-                    size="small"
-                    class="search-column"
-                  />
-                </div>
-
-                <div class="bulk-controls">
-                  <span class="bulk-label">Bulk Type:</span>
-                  <Select
-                    v-model="bulkTypeValue"
-                    size="small"
-                    :options="PARAMETER_TYPE_OPTIONS"
-                    optionLabel="label"
-                    optionValue="value"
-                    placeholder="Select type..."
-                    class="bulk-select"
-                  />
-                  <Button
-                    size="small"
-                    :disabled="selectedRows.length === 0"
-                    @click="applyBulkType"
-                  >
-                    Apply ({{ selectedRows.length }})
-                  </Button>
-                </div>
-              </div>
-
-              <DataTable
-                ref="parametersTable"
-                v-model:selection="selectedRows"
-                :value="filteredParameterRows"
-                dataKey="name"
-                scrollable
-                scrollHeight="480px"
-                tableStyle="min-width: 100%"
-                :sortField="sortField"
-                :sortOrder="sortOrder"
-                class="p-datatable-sm parameters-table"
-                @sort="handleSortChange"
-              >
-                <Column selectionMode="multiple" headerStyle="width: 2.2rem" />
-                <Column field="name" bodyClass="small-text-col" header="Name" sortable style="min-width: 140px" />
-                <Column field="value" header="Value" sortable style="min-width: 150px">
-                  <template #body="slotProps">
-                    <InputText
-                      v-if="isEditableVariableType(slotProps.data.type)"
-                      v-model="slotProps.data.value"
-                      size="small"
-                      placeholder="Enter value..."
-                      class="w-full"
-                    />
-                    <span v-else class="text-muted">-</span>
-                  </template>
-                </Column>
-                <Column field="units" bodyClass="small-text-col" header="Units" sortable style="min-width: 100px" />
-                <Column field="type" header="Type" sortable style="min-width: 180px">
-                  <template #body="slotProps">
+            <TabPanel value="parameters" class="tab-panel-flex">
+              <div class="parameters-tab-body">
+                <div class="toolbar-container">
+                  <div class="search-group">
+                    <div class="search-input-wrapper">
+                      <InputText
+                        v-model="searchQuery"
+                        size="small"
+                        :placeholder="`Search by ${searchColumn}...`"
+                        class="search-input"
+                      />
+                      <Button
+                        v-if="searchQuery"
+                        icon="pi pi-times"
+                        text
+                        rounded
+                        severity="secondary"
+                        size="small"
+                        class="clear-search-btn"
+                        @click="searchQuery = ''"
+                      />
+                    </div>
                     <Select
-                      v-model="slotProps.data.type"
-                      :options="PARAMETER_TYPE_OPTIONS"
+                      v-model="searchColumn"
+                      :options="searchColumnOptions"
                       optionLabel="label"
                       optionValue="value"
                       size="small"
-                      class="w-full"
+                      class="search-column"
                     />
-                  </template>
-                </Column>
-              </DataTable>
+                  </div>
+
+                  <div class="bulk-controls">
+                    <span class="bulk-label">Bulk Type:</span>
+                    <Select
+                      v-model="bulkTypeValue"
+                      size="small"
+                      :options="PARAMETER_TYPE_OPTIONS"
+                      optionLabel="label"
+                      optionValue="value"
+                      placeholder="Select type..."
+                      class="bulk-select"
+                    />
+                    <Button
+                      size="small"
+                      :disabled="selectedRows.length === 0"
+                      @click="applyBulkType"
+                    >
+                      Apply ({{ selectedRows.length }})
+                    </Button>
+                  </div>
+                </div>
+
+                <div class="table-flex-wrapper">
+                  <DataTable
+                    ref="parametersTable"
+                    v-model:selection="selectedRows"
+                    :value="filteredParameterRows"
+                    dataKey="name"
+                    scrollable
+                    scrollHeight="flex"
+                    tableStyle="min-width: 100%"
+                    :sortField="sortField"
+                    :sortOrder="sortOrder"
+                    class="p-datatable-sm parameters-table"
+                    @sort="handleSortChange"
+                  >
+                    <Column selectionMode="multiple" headerStyle="width: 2.2rem" />
+                    <Column field="name" bodyClass="small-text-col" header="Name" sortable style="min-width: 150px" />
+                    <Column field="value" header="Value" sortable style="min-width: 160px">
+                      <template #body="slotProps">
+                        <InputText
+                          v-if="isEditableVariableType(slotProps.data.type)"
+                          v-model="slotProps.data.value"
+                          size="small"
+                          placeholder="Enter value..."
+                          class="w-full"
+                        />
+                        <span v-else class="text-muted">-</span>
+                      </template>
+                    </Column>
+                    <Column field="units" bodyClass="small-text-col" header="Units" sortable style="min-width: 110px" />
+                    <Column field="type" header="Type" sortable style="min-width: 200px">
+                      <template #body="slotProps">
+                        <Select
+                          v-model="slotProps.data.type"
+                          :options="PARAMETER_TYPE_OPTIONS"
+                          optionLabel="label"
+                          optionValue="value"
+                          size="small"
+                          class="w-full"
+                        />
+                      </template>
+                    </Column>
+                  </DataTable>
+                </div>
+              </div>
             </TabPanel>
 
             <!-- TAB 2: PORT EDITOR -->
-            <TabPanel value="ports">
+            <TabPanel value="ports" class="tab-panel-flex">
               <div class="ports-tab-body">
                 <div class="ports-header">
                   <label class="form-label">Port Definitions</label>
                   <Button icon="pi pi-plus" label="Add Port" severity="success" size="small" rounded outlined @click="addPort" />
                 </div>
 
-                <div v-if="editablePorts.length" class="mt-2 overflow-x-auto">
-                  <DataTable :value="editablePorts" size="small" stripedRows scrollable scrollHeight="380px">
-                    <Column header="Type" style="width: 110px">
+                <div v-if="editablePorts.length" class="table-flex-wrapper">
+                  <DataTable :value="editablePorts" size="small" stripedRows scrollable scrollHeight="flex">
+                    <Column header="Type" style="min-width: 160px">
                       <template #body="slotProps">
                         <Select
                           v-model="slotProps.data.portType"
@@ -161,13 +203,13 @@
                       </template>
                     </Column>
 
-                    <Column header="Label" style="width: 160px">
+                    <Column header="Label" style="min-width: 170px">
                       <template #body="slotProps">
                         <InputText v-model="slotProps.data.label" placeholder="Enter label" size="small" class="w-full" />
                       </template>
                     </Column>
 
-                    <Column header="Variable(s)" style="min-width: 160px">
+                    <Column header="Variable(s)" style="min-width: 220px">
                       <template #body="slotProps">
                         <Select
                           v-model="slotProps.data.variables"
@@ -182,7 +224,7 @@
                       </template>
                     </Column>
 
-                    <Column header="Multiport" style="width: 130px">
+                    <Column header="Multiport" style="min-width: 190px">
                       <template #body="slotProps">
                         <div class="flex flex-col gap-1">
                           <Select
@@ -208,7 +250,7 @@
                       </template>
                     </Column>
 
-                    <Column header="" style="width: 50px">
+                    <Column header="" style="width: 56px">
                       <template #body="slotProps">
                         <Button
                           icon="pi pi-trash"
@@ -255,7 +297,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onBeforeUnmount } from 'vue'
 import { useVueFlow } from '@vue-flow/core'
 
 import Button from 'primevue/button'
@@ -331,6 +373,93 @@ const sortOrder = ref(1)
 // Port & Instance State
 const editableName = ref('')
 const editablePorts = ref([])
+
+// ── Split / Collapse State ──────────────────────────────────────────────────
+const SPLIT_STORAGE_KEY = 'instanceEditorDialog.leftPanePercent'
+const DEFAULT_LEFT_PERCENT = 55
+const MIN_LEFT_PERCENT = 32
+const MAX_LEFT_PERCENT = 72
+
+function loadStoredSplit() {
+  try {
+    const stored = Number(window.localStorage.getItem(SPLIT_STORAGE_KEY))
+    if (Number.isFinite(stored) && stored >= MIN_LEFT_PERCENT && stored <= MAX_LEFT_PERCENT) {
+      return stored
+    }
+  } catch (e) {
+    // localStorage unavailable (e.g. private browsing) - fall back to default
+  }
+  return DEFAULT_LEFT_PERCENT
+}
+
+const editorGridRef = ref(null)
+const leftPercent = ref(loadStoredSplit())
+const rightCollapsed = ref(false)
+const dragging = ref(false)
+
+const leftPaneStyle = computed(() => {
+  if (rightCollapsed.value) return { flex: '1 1 auto' }
+  return { flex: `0 0 ${leftPercent.value}%` }
+})
+
+function clampPercent(value) {
+  return Math.min(MAX_LEFT_PERCENT, Math.max(MIN_LEFT_PERCENT, value))
+}
+
+function updateSplitFromClientX(clientX) {
+  const grid = editorGridRef.value
+  if (!grid) return
+  const rect = grid.getBoundingClientRect()
+  if (!rect.width) return
+  const percent = ((clientX - rect.left) / rect.width) * 100
+  leftPercent.value = clampPercent(percent)
+}
+
+function persistSplit() {
+  try {
+    window.localStorage.setItem(SPLIT_STORAGE_KEY, String(leftPercent.value))
+  } catch (e) {
+    // ignore storage errors
+  }
+}
+
+function onResizeMove(event) {
+  if (!dragging.value) return
+  updateSplitFromClientX(event.clientX)
+}
+
+function stopResize() {
+  if (!dragging.value) return
+  dragging.value = false
+  window.removeEventListener('pointermove', onResizeMove)
+  persistSplit()
+}
+
+function startResize(event) {
+  if (rightCollapsed.value) return
+  dragging.value = true
+  event.target?.setPointerCapture?.(event.pointerId)
+  window.addEventListener('pointermove', onResizeMove)
+  window.addEventListener('pointerup', stopResize, { once: true })
+}
+
+function nudgeSplit(delta) {
+  leftPercent.value = clampPercent(leftPercent.value + delta)
+  persistSplit()
+}
+
+function resetSplit() {
+  leftPercent.value = DEFAULT_LEFT_PERCENT
+  persistSplit()
+}
+
+function toggleRightPanel() {
+  rightCollapsed.value = !rightCollapsed.value
+}
+
+onBeforeUnmount(() => {
+  window.removeEventListener('pointermove', onResizeMove)
+})
 
 // ── Computed ─────────────────────────────────────────────────────────────────
 const componentFile = computed(() => props.mathRef?.split(':')[0])
@@ -555,12 +684,22 @@ async function handleSave() {
 </script>
 
 <style scoped>
+/* ── Design tokens (kept local to this dialog for consistent typography) ── */
 .editor-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
-  height: 72vh;
-  min-height: 550px;
+  --dlg-fs-label: 0.875rem;   /* 14px - field/section labels */
+  --dlg-fs-body: 0.875rem;    /* 14px - table cells, inputs */
+  --dlg-fs-small: 0.8125rem;  /* 13px - secondary/meta text */
+  --dlg-fs-tiny: 0.75rem;     /* 12px - badges, prefixes only */
+
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  height: clamp(520px, 78vh, 940px);
+}
+
+.editor-grid.is-dragging {
+  cursor: col-resize;
+  user-select: none;
 }
 
 .pane {
@@ -571,13 +710,12 @@ async function handleSave() {
   border-radius: 8px;
   padding: 12px;
   overflow: hidden;
+  min-width: 0;
+  min-height: 0;
 }
 
-.pane-title {
-  font-weight: 600;
-  font-size: 0.95rem;
-  margin-bottom: 8px;
-  color: var(--p-text-color);
+.left-pane {
+  min-width: 340px;
 }
 
 .editor-wrapper {
@@ -585,20 +723,173 @@ async function handleSave() {
   min-height: 0;
 }
 
-.tab-icon {
-  margin-right: 6px;
-  font-size: 0.85rem;
+/* ── Resize handle between the two panes; also hosts the collapse/expand button ── */
+.resizer {
+  position: relative;
+  flex: 0 0 14px;
+  margin: 0 -3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: col-resize;
+  z-index: 2;
+  touch-action: none;
+}
+
+.resizer--collapsed {
+  cursor: pointer;
+}
+
+.resizer-grip {
+  width: 4px;
+  height: 48px;
+  border-radius: 3px;
+  background: var(--p-content-border-color);
+  transition: background-color 0.15s ease, opacity 0.15s ease;
+}
+
+.resizer--collapsed .resizer-grip {
+  opacity: 0.35;
+}
+
+.resizer:hover .resizer-grip,
+.resizer:focus-visible .resizer-grip {
+  background: var(--p-primary-color);
+}
+
+.resizer:focus-visible {
+  outline: none;
+}
+
+.resizer-toggle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 1.5rem;
+  height: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 999px;
+  background: var(--p-content-background);
+  color: var(--p-text-muted-color);
+  cursor: pointer;
+  z-index: 3;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+  opacity: 0;
+  transition: opacity 0.15s ease, color 0.15s ease, background-color 0.15s ease;
+}
+
+.resizer:hover .resizer-toggle,
+.resizer:focus-visible .resizer-toggle,
+.resizer--collapsed .resizer-toggle {
+  opacity: 1;
+}
+
+.resizer-toggle:hover {
+  color: var(--p-text-color);
+  background: var(--p-content-hover-background, rgba(0, 0, 0, 0.04));
+}
+
+/* ── Right pane / collapse behaviour ── */
+.right-pane {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 360px;
+  transition: min-width 0.15s ease, flex-basis 0.15s ease;
+}
+
+.right-pane--collapsed {
+  flex: 0 0 32px;
+  min-width: 32px;
+  padding: 8px 4px;
+  align-items: center;
+}
+
+.collapsed-rail {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.collapsed-rail-label {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  font-size: var(--dlg-fs-label);
+  font-weight: 600;
+  color: var(--p-text-muted-color);
+  white-space: nowrap;
+}
+
+/* ── Tabs: make the whole chain fill available height so the scroll ── */
+/* region reaches the bottom of the panel instead of leaving blank   */
+/* space underneath it on taller screens.                            */
+.right-pane-tabs {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.right-pane-tabs :deep(.p-tablist) {
+  flex-shrink: 0;
 }
 
 .tab-panels-container {
   flex: 1;
-  overflow-y: auto;
+  min-height: 0;
   padding-top: 12px;
+}
+
+.right-pane-tabs :deep(.p-tabpanels) {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.tab-panel-flex {
+  flex: 1;
+  min-height: 0;
+  height: 100%;
+}
+
+.right-pane-tabs :deep(.p-tabpanel) {
+  height: 100%;
+}
+
+.parameters-tab-body,
+.ports-tab-body {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.table-flex-wrapper {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.tab-icon {
+  margin-right: 6px;
+  font-size: var(--dlg-fs-small);
 }
 
 /* Parameters Tab Styles */
 .toolbar-container {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
@@ -613,6 +904,7 @@ async function handleSave() {
   display: flex;
   align-items: center;
   gap: 6px;
+  flex-wrap: wrap;
 }
 
 .search-input-wrapper {
@@ -628,9 +920,9 @@ async function handleSave() {
   height: 1.25rem !important;
 }
 
-.search-column { width: 90px; }
-.bulk-select { width: 140px; }
-.bulk-label { font-size: 0.8rem; color: var(--p-text-muted-color); }
+.search-column { width: 130px; }
+.bulk-select { width: 180px; }
+.bulk-label { font-size: var(--dlg-fs-small); color: var(--p-text-muted-color); white-space: nowrap; }
 
 /* Ports Tab Styles */
 .form-field {
@@ -641,7 +933,7 @@ async function handleSave() {
 
 .form-label {
   font-weight: 600;
-  font-size: 0.9rem;
+  font-size: var(--dlg-fs-label);
 }
 
 .ports-header {
@@ -649,23 +941,40 @@ async function handleSave() {
   align-items: center;
   justify-content: space-between;
   margin-bottom: 8px;
+  flex-shrink: 0;
 }
 
 .empty-state {
   color: var(--p-text-muted-color);
-  font-size: 0.85rem;
+  font-size: var(--dlg-fs-small);
   margin-top: 16px;
   text-align: center;
 }
 
 .multiply-prefix {
-  font-size: 12px;
+  font-size: var(--dlg-fs-tiny);
   font-weight: 600;
   color: var(--p-text-muted-color);
 }
 
 .w-full { width: 100%; }
 .text-muted { color: var(--p-text-muted-color); }
+
+/* Normalise table typography - DataTable renders these cells directly */
+/* in our own template output (not teleported), so :deep() reaches them. */
+.right-pane :deep(.p-datatable) {
+  font-size: var(--dlg-fs-body);
+}
+
+.right-pane :deep(.p-datatable-thead > tr > th) {
+  font-size: var(--dlg-fs-small);
+  font-weight: 600;
+}
+
+.right-pane :deep(.p-select-label),
+.right-pane :deep(.p-inputtext) {
+  font-size: var(--dlg-fs-body);
+}
 
 /* Footer */
 .dialog-footer {
@@ -698,4 +1007,29 @@ async function handleSave() {
   gap: 12px;
 }
 
+@media (max-width: 900px) {
+  .editor-grid {
+    flex-direction: column;
+    height: auto;
+    max-height: 78vh;
+  }
+
+  .left-pane {
+    min-width: 0;
+    flex-basis: 45vh !important;
+  }
+
+  .resizer {
+    display: none;
+  }
+
+  .right-pane {
+    flex-basis: 45vh !important;
+    min-width: 0;
+  }
+
+  .right-pane--collapsed {
+    display: none;
+  }
+}
 </style>

--- a/src/components/InstanceEditorDialog.vue
+++ b/src/components/InstanceEditorDialog.vue
@@ -142,15 +142,15 @@
                     dataKey="name"
                     scrollable
                     scrollHeight="flex"
-                    tableStyle="min-width: 100%"
+                    tableStyle="min-width: 520px"
                     :sortField="sortField"
                     :sortOrder="sortOrder"
                     class="p-datatable-sm parameters-table"
                     @sort="handleSortChange"
                   >
                     <Column selectionMode="multiple" headerStyle="width: 2.2rem" />
-                    <Column field="name" bodyClass="small-text-col" header="Name" sortable style="min-width: 150px" />
-                    <Column field="value" header="Value" sortable style="min-width: 160px">
+                    <Column field="name" bodyClass="small-text-col" header="Name" sortable style="min-width: 120px" />
+                    <Column field="value" header="Value" sortable style="min-width: 120px">
                       <template #body="slotProps">
                         <InputText
                           v-if="isEditableVariableType(slotProps.data.type)"
@@ -163,7 +163,7 @@
                       </template>
                     </Column>
                     <Column field="units" bodyClass="small-text-col" header="Units" sortable style="min-width: 110px" />
-                    <Column field="type" header="Type" sortable style="min-width: 200px">
+                    <Column field="type" header="Type" sortable style="min-width: 170px">
                       <template #body="slotProps">
                         <Select
                           v-model="slotProps.data.type"
@@ -189,8 +189,8 @@
                 </div>
 
                 <div v-if="editablePorts.length" class="table-flex-wrapper">
-                  <DataTable :value="editablePorts" size="small" stripedRows scrollable scrollHeight="flex">
-                    <Column header="Type" style="min-width: 160px">
+                  <DataTable :value="editablePorts" size="small" stripedRows scrollHeight="flex">
+                    <Column header="Type" style="min-width: 50px">
                       <template #body="slotProps">
                         <Select
                           v-model="slotProps.data.portType"
@@ -211,20 +211,20 @@
 
                     <Column header="Variable(s)" style="min-width: 220px">
                       <template #body="slotProps">
-                        <Select
+                        <MultiSelect
                           v-model="slotProps.data.variables"
                           :options="variables"
                           optionLabel="name"
                           optionValue="name"
-                          multiple
                           size="small"
                           placeholder="Select variables"
                           class="w-full"
+                          :maxSelectedLabels="3"
                         />
                       </template>
                     </Column>
 
-                    <Column header="Multiport" style="min-width: 190px">
+                    <Column header="Multiport" style="min-width: 50px">
                       <template #body="slotProps">
                         <div class="flex flex-col gap-1">
                           <Select
@@ -310,6 +310,7 @@ import InputNumber from 'primevue/inputnumber'
 import InputText from 'primevue/inputtext'
 import ProgressSpinner from 'primevue/progressspinner'
 import Select from 'primevue/select'
+import MultiSelect from 'primevue/multiselect'
 import Tab from 'primevue/tab'
 import TabList from 'primevue/tablist'
 import TabPanel from 'primevue/tabpanel'
@@ -377,7 +378,7 @@ const editablePorts = ref([])
 // ── Split / Collapse State ──────────────────────────────────────────────────
 const SPLIT_STORAGE_KEY = 'instanceEditorDialog.leftPanePercent'
 const DEFAULT_LEFT_PERCENT = 55
-const MIN_LEFT_PERCENT = 32
+const MIN_LEFT_PERCENT = 40
 const MAX_LEFT_PERCENT = 72
 
 function loadStoredSplit() {
@@ -498,7 +499,12 @@ watch(
 
       // Load Instance & Port data
       editableName.value = props.initialName
-      editablePorts.value = detachReactivity(props.initialPorts || [])
+      editablePorts.value = detachReactivity(props.initialPorts || []).map((port) => ({
+        ...port,
+        variables: Array.isArray(port.variables)
+          ? port.variables.map((v) => (typeof v === 'object' && v !== null ? v.name : v))
+          : []
+      }))
 
       // Load Parameters
       parameterRows.value = props.variables.map((row) => ({

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -135,7 +135,7 @@ import Menu from 'primevue/menu'
 import CellMLIcon from './icons/CellMLIcon.vue'
 import { useLibraryStore } from '../stores/libraryStore'
 import { useFlowHistoryStore } from '../stores/historyStore'
-import { getHandleId, getHandleStyle, handlePosition, findMostCentralGhostHandle, isCornerHandle } from '../utils/handles'
+import { getHandleId, getHandleStyle, handlePosition, isCornerHandle } from '../utils/handles'
 import { sanitiseName } from '../utils/nodes'
 import { notify } from '../utils/notify'
 import { isEditableVariableType, isEmpty } from '../utils/variables'
@@ -146,7 +146,7 @@ import { useHandleManagement } from '../composables/useHandleManagement'
 import '../assets/vueflownode.css'
 
 const { addEdges, edges, removeEdges, updateNodeData, updateNodeInternals, nodes } = useVueFlow()
-const { beginGhostActivation, activateHandle } = useHandleManagement()
+const { beginGhostActivation, activateHandle, addHandle } = useHandleManagement()
 const historyStore = useFlowHistoryStore()
 const libraryStore = useLibraryStore()
 
@@ -252,10 +252,10 @@ function togglePortMenu(event) {
 }
 
 const portMenuItems = [
-  { label: 'Left', command: () => addHandle({ side: 'left' }) },
-  { label: 'Right', command: () => addHandle({ side: 'right' }) },
-  { label: 'Top', command: () => addHandle({ side: 'top' }) },
-  { label: 'Bottom', command: () => addHandle({ side: 'bottom' }) },
+  { label: 'Left', command: () => addHandle(props.id, 'left') },
+  { label: 'Right', command: () => addHandle(props.id, 'right') },
+  { label: 'Top', command: () => addHandle(props.id, 'top') },
+  { label: 'Bottom', command: () => addHandle(props.id, 'bottom') },
 ]
 
 const applyHandles = async (handlesToSet) => {
@@ -335,16 +335,6 @@ async function removeHandle(handleIdToRemove) {
       await applyHandles(newHandles)
     },
   })
-}
-
-const addHandle = async (handleToAdd) => {
-  const mostCentralGhost = findMostCentralGhostHandle(handleToAdd.side, props.data.handles)
-
-  if (!mostCentralGhost) {
-    return
-  }
-
-  await activateHandle(props.id, mostCentralGhost.uid)
 }
 
 const isEditing = ref(false)

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -61,34 +61,9 @@
           severity="secondary"
           class="instance-button"
           icon="pi pi-pencil"
-          @click="openPortEditDialog"
-          v-tooltip.bottom="{ value: 'Edit ports', showDelay: 300 }"
+          @click="openInstanceEditor('parameters')"
+          v-tooltip.bottom="{ value: 'Edit instance', showDelay: 300 }"
         />
-
-        <Button
-          rounded
-          iconOnly
-          size="small"
-          severity="secondary"
-          class="instance-button"
-          icon="pi pi-sliders-h"
-          @click="openParameterEditDialog"
-          v-tooltip.bottom="{ value: 'Edit parameters', showDelay: 300 }"
-        />
-
-        <Button
-          rounded
-          iconOnly
-          size="small"
-          severity="secondary"
-          class="instance-button"
-          @click="openCellmlEditDialog"
-          v-tooltip.bottom="{ value: 'Edit CellML Text', showDelay: 300 }"
-        >
-          <template #icon>
-            <CellMLIcon class="p-button-icon" />
-          </template>
-        </Button>
       </div>
     </div>
 
@@ -160,39 +135,22 @@ const props = defineProps({
 })
 
 const emit = defineEmits([
-  'open-cellml-editor-dialog',
-  'open-port-editor-dialog',
-  'open-parameter-editor-dialog',
+  'open-instance-editor',
   'open-context-menu',
 ])
 
 const domainMenuId = `domain-type-menu-${props.id}`
 const portMenuId = `port-menu-${props.id}`
 
-async function openPortEditDialog() {
-  emit('open-port-editor-dialog', {
-    id: props.id,
-    handles: props.data.handles,
-    initialName: props.data.name,
-    initialPorts: props.data.ports,
-    variables: props.data.variables,
-  })
-}
-
-function openCellmlEditDialog() {
-  emit('open-cellml-editor-dialog', {
+function openInstanceEditor(defaultTab = 'parameters') {
+  emit('open-instance-editor', {
     id: props.id,
     name: props.data.name,
     mathRef: props.data.mathRef,
     variables: props.data.variables,
-  })
-}
-
-function openParameterEditDialog() {
-  emit('open-parameter-editor-dialog', {
-    id: props.id,
-    variables: props.data.variables,
-    mathRef: props.data.mathRef,
+    ports: props.data.ports,
+    handles: props.data.handles,
+    defaultTab,
   })
 }
 

--- a/src/components/InstanceNode.vue
+++ b/src/components/InstanceNode.vue
@@ -10,50 +10,14 @@
     <NodeResizer min-width="200" min-height="120" :is-visible="selected" />
 
     <div :class="[domainTypeClass, 'instance-card']">
-      <div v-if="isMissingParameters" class="status-indicator">
-        <i
-          class="pi pi-exclamation-triangle warning-icon"
-          v-tooltip.top="'At least one parameter has not been assigned a value'"
-        ></i>
-      </div>
-
-      <div class="instance-name" @dblclick="startEditing">
-        <span v-if="!isEditing">
-          {{ data.name }}
-        </span>
-        <InputText v-else ref="inputRef" v-model="editingName" size="small" @blur="saveEdit" @keyup.enter="saveEdit" />
-      </div>
-
-      <div class="instance-label">{{ instanceLabel }}</div>
-      <div class="button-group">
-        <Button
-          rounded
-          iconOnly
-          size="small"
-          severity="secondary"
-          class="instance-button"
-          icon="pi pi-key"
-          @click="toggleDomainMenu"
-          v-tooltip.bottom="{ value: 'Set key (colour)', showDelay: 300 }"
-          aria-haspopup="true"
-          :aria-controls="domainMenuId"
-        />
-        <Menu :id="domainMenuId" ref="domainMenuRef" :model="domainTypeMenuItems" popup class="content-fit-menu" />
-
-        <Button
-          rounded
-          iconOnly
-          size="small"
-          severity="secondary"
-          class="instance-button"
-          icon="pi pi-map-marker"
-          @click="togglePortMenu"
-          v-tooltip.bottom="{ value: 'Add handle', showDelay: 300 }"
-          aria-haspopup="true"
-          :aria-controls="portMenuId"
-        />
-        <Menu :id="portMenuId" ref="portMenuRef" :model="portMenuItems" popup class="content-fit-menu" />
-
+      <!-- Top Actions Row -->
+      <div class="card-header-actions">
+        <div v-if="isMissingParameters" class="status-indicator">
+          <i
+            class="pi pi-exclamation-triangle warning-icon"
+            v-tooltip.top="'At least one parameter has not been assigned a value'"
+          ></i>
+        </div>
         <Button
           rounded
           iconOnly
@@ -64,6 +28,26 @@
           @click="openInstanceEditor('parameters')"
           v-tooltip.bottom="{ value: 'Edit instance', showDelay: 300 }"
         />
+      </div>
+
+      <!-- Node Title Block -->
+      <div class="instance-name" @dblclick="startEditing">
+        <span v-if="!isEditing" class="name-text">
+          {{ data.name }}
+        </span>
+        <InputText v-else ref="inputRef" v-model="editingName" size="small" @blur="saveEdit" @keyup.enter="saveEdit" />
+      </div>
+
+      <!-- Metadata Footer Block -->
+      <div class="instance-details">
+        <div class="detail-item">
+          <i class="pi pi-box detail-icon"></i>
+          <span class="detail-value">{{ componentName }}</span>
+        </div>
+        <div class="detail-item">
+          <i class="pi pi-file detail-icon"></i>
+          <span class="detail-value">{{ mathFile }}</span>
+        </div>
       </div>
     </div>
 
@@ -96,7 +80,7 @@
           @click.stop="removeHandle(handle.uid)"
         />
       </Handle>
-  </template>
+    </template>
   </div>
 </template>
 
@@ -160,9 +144,9 @@ function openInstanceEditor(defaultTab = 'parameters') {
   })
 }
 
-const instanceLabel = computed(() => {
-  return `${props.data.mathRef.split(':')[1]} — ${props.data.mathRef.split(':')[0]}`
-})
+const componentName = props.data.mathRef.split(':')[1]
+
+const mathFile = props.data.mathRef.split(':')[0]
 
 const domainTypeClass = computed(() => {
   return props.data.domainType ? `domain-type-${props.data.domainType}` : 'domain-type-default'
@@ -208,13 +192,6 @@ const portMenuRef = ref(null)
 function togglePortMenu(event) {
   portMenuRef.value?.toggle(event)
 }
-
-const portMenuItems = [
-  { label: 'Left', command: () => addHandle(props.id, 'left') },
-  { label: 'Right', command: () => addHandle(props.id, 'right') },
-  { label: 'Top', command: () => addHandle(props.id, 'top') },
-  { label: 'Bottom', command: () => addHandle(props.id, 'bottom') },
-]
 
 const applyHandles = async (handlesToSet) => {
   updateNodeData(props.id, { handles: handlesToSet })
@@ -386,17 +363,28 @@ function openContextMenu(event) {
 }
 
 .instance-name {
-  min-height: 2.5rem; 
+  margin-top: auto; 
+  min-height: 2rem; 
+  margin-left: 1%;
   display: flex;
   align-items: center;
   width: 100%; 
-  margin-bottom: -4px;
+  font-weight: 600;
+  font-size: 1.2rem;
+  padding-bottom: 0.25rem;
+  margin-bottom: 0.35rem;
 }
 
 .instance-name :deep(.p-inputtext) {
   width: 100%;
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
+  padding-top: 0.2rem;
+  padding-bottom: 0.2rem;
+}
+
+.name-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .instance-node {
@@ -418,31 +406,19 @@ function openContextMenu(event) {
   border: 3px solid color-mix(in srgb, var(--p-text-color) 4%, transparent);
   box-shadow: 0 1px 2px color-mix(in srgb, var(--p-text-color) 6%, transparent);
   transition: box-shadow 120ms ease;
-  padding: 0.75rem;
+  padding: 0.5rem 0.75rem 0.65rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 
 .instance-card:hover {
   box-shadow: 0 4px 10px color-mix(in srgb, var(--p-text-color) 12%, transparent);
 }
 
-.status-indicator {
-  position: absolute;
-  top: 3px;
-  right: 3px;
-  z-index: 10;
-  background-color: color-mix(in srgb, var(--p-orange-500) 20%, var(--p-content-background));
-  border-radius: 50%;
-  width: 20px;
-  height: 20px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 2px 4px color-mix(in srgb, var(--p-text-color) 10%, transparent);
-}
-
 .warning-icon {
   color: var(--p-orange-500);
-  font-size: 18px;
+  font-size: 0.85rem;
   cursor: help;
 }
 
@@ -450,13 +426,62 @@ function openContextMenu(event) {
   color: var(--p-orange-600);
 }
 
+.card-header-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.35rem;
+  width: 100%;
+  min-height: 1.6rem;
+  z-index: 10;
+}
+
+.instance-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.detail-item {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  color: color-mix(in srgb, var(--p-text-color) 70%, transparent);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.detail-icon {
+  font-size: 0.7rem;
+  flex-shrink: 0;
+  opacity: 0.8;
+}
+
+.detail-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .instance-button {
   margin: 0;
   flex-shrink: 0; 
-
-  width: 1.75rem !important;
-  height: 1.75rem !important;
+  width: 1.6rem !important;
+  height: 1.6rem !important;
   padding: 0 !important;
+}
+
+.status-indicator {
+  background-color: color-mix(in srgb, var(--p-orange-500) 20%, var(--p-content-background));
+  border-radius: 50%;
+  width: 1.6rem;
+  height: 1.6rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 4px color-mix(in srgb, var(--p-text-color) 10%, transparent);
 }
 
 .instance-button :deep(.p-button-icon),
@@ -464,12 +489,6 @@ function openContextMenu(event) {
   font-size: 0.75rem !important;
   width: 0.75rem;
   height: 0.75rem;
-}
-
-.button-group {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
 }
 
 /* Base appearance for the popover */

--- a/src/components/icons/AddHandles/AddHandleBottom.vue
+++ b/src/components/icons/AddHandles/AddHandleBottom.vue
@@ -1,0 +1,17 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 1683.5 1683.78"
+    width="1em"
+    height="1em"
+  >
+    <path
+      fill="none"
+      stroke="currentColor"
+      stroke-width="150"
+      stroke-miterlimit="10"
+      d="M1421.51,1249.7H261.99c-61.49,0-111.34-49.85-111.34-111.34V545.42c0-61.49,49.85-111.34,111.34-111.34h1159.52c61.49,0,111.34,49.85,111.34,111.34v592.94C1532.85,1199.85,1483,1249.7,1421.51,1249.7z"
+    />
+    <circle fill="currentColor" cx="841.75" cy="1249.73" r="200" />
+  </svg>
+</template>

--- a/src/components/icons/AddHandles/AddHandleLeft.vue
+++ b/src/components/icons/AddHandles/AddHandleLeft.vue
@@ -1,0 +1,17 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 1683.5 1683.78"
+    width="1em"
+    height="1em"
+  >
+    <path
+      fill="none"
+      stroke="currentColor"
+      stroke-width="150"
+      stroke-miterlimit="10"
+      d="M1421.51,1249.7H261.99c-61.49,0-111.34-49.85-111.34-111.34V545.42c0-61.49,49.85-111.34,111.34-111.34h1159.52c61.49,0,111.34,49.85,111.34,111.34v592.94C1532.85,1199.85,1483,1249.7,1421.51,1249.7z"
+    />
+    <circle fill="currentColor" cx="150.65" cy="841.89" r="200" />
+  </svg>
+</template>

--- a/src/components/icons/AddHandles/AddHandleRight.vue
+++ b/src/components/icons/AddHandles/AddHandleRight.vue
@@ -1,0 +1,17 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 1683.5 1683.78"
+    width="1em"
+    height="1em"
+  >
+    <path
+      fill="none"
+      stroke="currentColor"
+      stroke-width="150"
+      stroke-miterlimit="10"
+      d="M1421.51,1249.7H261.99c-61.49,0-111.34-49.85-111.34-111.34V545.42c0-61.49,49.85-111.34,111.34-111.34h1159.52c61.49,0,111.34,49.85,111.34,111.34v592.94C1532.85,1199.85,1483,1249.7,1421.51,1249.7z"
+    />
+    <circle fill="currentColor" cx="1532.85" cy="841.89" r="200" />
+  </svg>
+</template>

--- a/src/components/icons/AddHandles/AddHandleTop.vue
+++ b/src/components/icons/AddHandles/AddHandleTop.vue
@@ -1,0 +1,17 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 1683.5 1683.78"
+    width="1em"
+    height="1em"
+  >
+    <path
+      fill="none"
+      stroke="currentColor"
+      stroke-width="150"
+      stroke-miterlimit="10"
+      d="M1421.51,1249.7H261.99c-61.49,0-111.34-49.85-111.34-111.34V545.42c0-61.49,49.85-111.34,111.34-111.34h1159.52c61.49,0,111.34,49.85,111.34,111.34v592.94C1532.85,1199.85,1483,1249.7,1421.51,1249.7z"
+    />
+    <circle fill="currentColor" cx="841.75" cy="434.08" r="200" />
+  </svg>
+</template>

--- a/src/composables/useHandleManagement.js
+++ b/src/composables/useHandleManagement.js
@@ -2,7 +2,7 @@ import { nextTick, ref } from 'vue'
 import { useVueFlow } from '@vue-flow/core'
 import { useFlowHistoryStore } from '../stores/historyStore'
 import { HANDLE_VARIANT } from '../utils/constants'
-import { getHandleId, getHandleUidFromHandleId } from '../utils/handles'
+import { findMostCentralGhostHandle, getHandleId, getHandleUidFromHandleId } from '../utils/handles'
 import { detachReactivity } from '../utils/reactivity'
 
 const pendingGhostRevert = ref(null)
@@ -125,8 +125,19 @@ export function useHandleManagement() {
     }
   }
 
+  async function addHandle(nodeId, side) {
+    const node = getNodes.value.find((node) => node.id === nodeId)
+    if (!node) return
+
+    const mostCentralGhost = findMostCentralGhostHandle(side, node.data.handles)
+    if (!mostCentralGhost) return
+
+    await activateHandle(nodeId, mostCentralGhost.uid)
+  }
+
   return {
     activateHandle,
+    addHandle,
     beginGhostActivation,
     confirmActivation,
     revertPendingGhostIfUnused,

--- a/src/services/workspaceMigrator.js
+++ b/src/services/workspaceMigrator.js
@@ -5,8 +5,18 @@
 
 // Import the helper function (adjust path as needed)
 import { extractComponentsFromCellmlString } from "../utils/cellml"
-import { MAIN_NODE_TYPE, PORT_TYPE_OPTIONS, FORMAT_VERSION, DEFAULT_PROJECT_TYPE } from "../utils/constants"
+import {
+  MAIN_NODE_TYPE,
+  HANDLE_VARIANT,
+  NUM_GHOST_HANDLES_SIDES,
+  NUM_GHOST_HANDLES_TOP_BOT,
+  PORT_TYPE_OPTIONS,
+  FORMAT_VERSION,
+  DEFAULT_PROJECT_TYPE,
+  HANDLE_SIDES,
+} from "../utils/constants"
 import { normalisePorts, normaliseVariables } from "../utils/config"
+import { buildGhostHandles, findMostCentralGhostHandle } from "../utils/handles";
 
 function mergeVariables(oldData, nodeName, globalConstantNames, paramLookup) {
   const typeLookup = {};
@@ -60,17 +70,19 @@ function convertPorts(oldData) {
 }
 
 function convertHandles(oldData, uidMap) {
-  return (oldData.ports || []).map((port) => {
+  const migratedHandles = buildGhostHandles()
+  for (const port of oldData.ports) {
     const oldUid = port.uid
-    const newUid = crypto.randomUUID()
-    uidMap[oldUid] = newUid
-    return {
-      uid: newUid,
-      type: port.type,
-      side: port.side,
-      name: port.name,
+    const centralGhost = findMostCentralGhostHandle(port.side, migratedHandles)
+    if (!centralGhost) return
+    uidMap[oldUid] = centralGhost.uid
+    const handle = migratedHandles.find((h) => h.uid === centralGhost.uid)
+    if (handle) {
+      handle.variant = HANDLE_VARIANT.DEFAULT
+      handle.type = port.type 
     }
-  })
+  }
+  return migratedHandles
 }
 
 function convertNode(node, newId, globalConstantNames, paramLookup, uidMap) {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -26,9 +26,9 @@ export const FLOW_IDS = {
 
 export const PARAMETER_TYPE_OPTIONS = [
   { value: 'constant', label: 'constant' },
-  { value: 'global_constant', label: 'global_constant' },
+  { value: 'global_constant', label: 'global' },
   { value: 'variable', label: 'variable' },
-  { value: 'boundary_condition', label: 'boundary_condition' },
+  { value: 'boundary_condition', label: 'boundary' },
 ]
 
 export const AFFINE_UNIT_CONVERSIONS = {

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -550,6 +550,7 @@ const {
 
 const {
   activateHandle,
+  addHandle: addHandleToNode,
   confirmActivation,
   revertPendingGhostIfUnused,
   revertHandlesForEdge,
@@ -1199,9 +1200,7 @@ function updateHelperLines(changes, nodes) {
 
 const addHandle = async (side) => {
   for (const node of getSelectedNodes.value) {
-    const mostCentralGhost = findMostCentralGhostHandle(side, node.data.handles)
-    if (!mostCentralGhost) return
-    await activateHandle(node.id, mostCentralGhost.uid)
+    await addHandleToNode(node.id, side)
   }
 }
 

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -51,7 +51,8 @@
           <Divider layout="vertical" style="margin: 0 15px" />
 
           <Button
-            label="Undo"
+            iconOnly
+            icon="pi pi-undo"
             size="small"
             variant="text"
             severity="secondary"
@@ -60,7 +61,8 @@
           />
 
           <Button
-            label="Redo"
+            iconOnly
+            icon="pi pi-refresh"
             size="small"
             variant="text"
             severity="secondary"

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -293,18 +293,6 @@
     @confirm="onInstanceEditConfirm"
   />
 
-  const props = defineProps({
-  modelValue: { type: Boolean, default: false },
-  id: { type: String, required: true },
-  initialName: { type: String, default: '' },
-  mathRef: { type: String, required: true },
-  variables: { type: Array, default: () => [] },
-  initialPorts: { type: Array, default: () => [] },
-  existingNames: { type: Array, default: () => [] },
-  defaultTab: { type: String, default: 'parameters' }, // 'parameters' or 'ports'
-})
-
-
   <PortEditorDialog
     v-model="portEditorDialogVisible"
     :id="currentEditingNode?.id"

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -73,6 +73,24 @@
 
           <Divider layout="vertical" style="margin: 0 15px" />
 
+          <Button iconOnly variant="text" severity="secondary">
+            <AddHandleLeft/>
+          </Button>
+
+          <Button iconOnly style="margin-left: 10px" variant="text" severity="secondary">
+            <AddHandleTop/>
+          </Button>
+
+          <Button iconOnly style="margin-left: 10px" variant="text" severity="secondary">
+            <AddHandleRight/>
+          </Button>
+
+          <Button iconOnly style="margin-left: 10px" variant="text" severity="secondary">
+            <AddHandleBottom/>
+          </Button>
+
+          <Divider layout="vertical" style="margin: 0 15px" />
+
           <Button
             label="Macro Build"
             size="small"
@@ -446,6 +464,10 @@ import CellMLEditorDialog from '../components/CellMLEditorDialog.vue'
 import ParameterEditorDialog from '../components/ParameterEditorDialog.vue'
 import PortEditorDialog from '../components/PortEditorDialog.vue'
 import CellMLIcon from '../components/icons/CellMLIcon.vue'
+import AddHandleBottom from '../components/icons/AddHandles/AddHandleBottom.vue'
+import AddHandleLeft from '../components/icons/AddHandles/AddHandleLeft.vue'
+import AddHandleTop from '../components/icons/AddHandles/AddHandleTop.vue'
+import AddHandleRight from '../components/icons/AddHandles/AddHandleRight.vue'
 import { getHandleId, getHandleUidFromHandleId } from '../utils/handles'
 
 const workspaceFileInput = ref(null)

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -79,19 +79,50 @@
 
           <Divider layout="vertical" style="margin: 0 15px" />
 
-          <Button iconOnly variant="text" severity="secondary" v-tooltip.bottom="{ value: 'Add left handle', showDelay: 300 }" :disabled="!somethingSelected">
+          <Button
+            iconOnly
+            variant="text"
+            severity="secondary"
+            v-tooltip.bottom="{ value: 'Add left handle', showDelay: 300 }"
+            :disabled="!somethingSelected"
+            @click="addHandle('left')"
+          >
             <AddHandleLeft/>
           </Button>
 
-          <Button iconOnly style="margin-left: 10px" variant="text" severity="secondary" v-tooltip.bottom="{ value: 'Add top handle', showDelay: 300 }" :disabled="!somethingSelected">
+          <Button
+            iconOnly
+            style="margin-left: 10px"
+            variant="text"
+            severity="secondary"
+            v-tooltip.bottom="{ value: 'Add top handle', showDelay: 300 }"
+            :disabled="!somethingSelected"
+            @click="addHandle('top')"
+          >
             <AddHandleTop/>
           </Button>
 
-          <Button iconOnly style="margin-left: 10px" variant="text" severity="secondary" v-tooltip.bottom="{ value: 'Add right handle', showDelay: 300 }" :disabled="!somethingSelected">
+          <Button
+            iconOnly
+            style="margin-left: 10px"
+            variant="text"
+            severity="secondary"
+            v-tooltip.bottom="{ value: 'Add right handle', showDelay: 300 }"
+            :disabled="!somethingSelected"
+            @click="addHandle('right')"
+          >
             <AddHandleRight/>
           </Button>
 
-          <Button iconOnly style="margin-left: 10px" variant="text" severity="secondary" v-tooltip.bottom="{ value: 'Add bottom handle', showDelay: 300 }" :disabled="!somethingSelected">
+          <Button
+            iconOnly
+            style="margin-left: 10px"
+            variant="text"
+            severity="secondary"
+            v-tooltip.bottom="{ value: 'Add bottom handle', showDelay: 300 }"
+            :disabled="!somethingSelected"
+            @click="addHandle('bottom')"
+          >
             <AddHandleBottom/>
           </Button>
 
@@ -428,7 +459,6 @@ import { createCellMLDataFragment } from '../services/cellml'
 import { useMacroGenerator } from '../services/generate/generateWorkflow'
 import { migrateWorkspace } from '../services/workspaceMigrator'
 import { notify } from '../utils/notify'
-import { resolvePortCouplings } from '../utils/edges'
 import { getHelperLines } from '../utils/helperLines'
 import { getPurgedUrlForResource, getUrlForResource, loadManifest } from '../utils/resources'
 import { useClearWorkspace } from '../utils/workspace'
@@ -455,7 +485,7 @@ import {
   DEFAULT_PROJECT_TYPE,
 } from '../utils/constants'
 import { getId as getNextNodeId, generateUniqueInstanceName } from '../utils/nodes'
-import { getId as getNextEdgeId } from '../utils/edges'
+import { getId as getNextEdgeId, resolvePortCouplings } from '../utils/edges'
 import { getImportConfig, parseParametersFile } from '../utils/import'
 import { detachReactivity } from '../utils/reactivity'
 import {
@@ -474,7 +504,7 @@ import AddHandleBottom from '../components/icons/AddHandles/AddHandleBottom.vue'
 import AddHandleLeft from '../components/icons/AddHandles/AddHandleLeft.vue'
 import AddHandleTop from '../components/icons/AddHandles/AddHandleTop.vue'
 import AddHandleRight from '../components/icons/AddHandles/AddHandleRight.vue'
-import { getHandleId, getHandleUidFromHandleId } from '../utils/handles'
+import { getHandleId, getHandleUidFromHandleId, findMostCentralGhostHandle } from '../utils/handles'
 
 const workspaceFileInput = ref(null)
 
@@ -1164,6 +1194,14 @@ function updateHelperLines(changes, nodes) {
     helperLineHorizontal.value = helperLines.horizontal
     helperLineVertical.value = helperLines.vertical
     alignment.value = helperLines.alignment
+  }
+}
+
+const addHandle = async (side) => {
+  for (const node of getSelectedNodes.value) {
+    const mostCentralGhost = findMostCentralGhostHandle(side, node.data.handles)
+    if (!mostCentralGhost) return
+    await activateHandle(node.id, mostCentralGhost.uid)
   }
 }
 

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -12,14 +12,14 @@
             @change="handleLoadWorkspace"
           />
           <Button
-            label="Load Workspace"
+            icon="pi pi-folder-open"
             size="small"
             variant="text"
             @click="$refs.workspaceFileInput.click()"
           />
 
           <Button
-            label="Save Workspace"
+            icon="pi pi-save"
             size="small"
             variant="text"
             @click="handleSaveWorkspace"
@@ -30,7 +30,7 @@
           <Divider layout="vertical" style="margin: 0 15px" />
 
           <Button
-            label="Auto Layout"
+            icon="pi pi-sparkles"
             size="small"
             variant="text"
             severity="warn"
@@ -39,7 +39,7 @@
           />
 
           <Button
-            label="Clear"
+            icon="pi pi-eraser"
             size="small"
             variant="text"
             severity="danger"

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -15,6 +15,7 @@
             icon="pi pi-folder-open"
             size="small"
             variant="text"
+            v-tooltip.bottom="{ value: 'Load workspace', showDelay: 300 }"
             @click="$refs.workspaceFileInput.click()"
           />
 
@@ -22,6 +23,7 @@
             icon="pi pi-save"
             size="small"
             variant="text"
+            v-tooltip.bottom="{ value: 'Save workspace', showDelay: 300 }"
             @click="handleSaveWorkspace"
             style="margin-left: 10px"
             :disabled="!somethingAvailable"
@@ -34,6 +36,7 @@
             size="small"
             variant="text"
             severity="warn"
+            v-tooltip.bottom="{ value: 'Clean up workspace', showDelay: 300 }"
             @click="handleAutoLayout"
             :disabled="!somethingAvailable"
           />
@@ -43,6 +46,7 @@
             size="small"
             variant="text"
             severity="danger"
+            v-tooltip.bottom="{ value: 'Clear workspace', showDelay: 300 }"
             @click="handleClearWorkspace"
             style="margin-left: 10px"
             :disabled="!somethingAvailable"
@@ -56,6 +60,7 @@
             size="small"
             variant="text"
             severity="secondary"
+            v-tooltip.bottom="{ value: 'Undo', showDelay: 300 }"
             @click="handleUndo"
             :disabled="!historyStore.canUndo"
           />
@@ -66,6 +71,7 @@
             size="small"
             variant="text"
             severity="secondary"
+            v-tooltip.bottom="{ value: 'Redo', showDelay: 300 }"
             @click="handleRedo"
             style="margin-left: 10px"
             :disabled="!historyStore.canRedo"
@@ -73,19 +79,19 @@
 
           <Divider layout="vertical" style="margin: 0 15px" />
 
-          <Button iconOnly variant="text" severity="secondary">
+          <Button iconOnly variant="text" severity="secondary" v-tooltip.bottom="{ value: 'Add left handle', showDelay: 300 }" :disabled="!somethingSelected">
             <AddHandleLeft/>
           </Button>
 
-          <Button iconOnly style="margin-left: 10px" variant="text" severity="secondary">
+          <Button iconOnly style="margin-left: 10px" variant="text" severity="secondary" v-tooltip.bottom="{ value: 'Add top handle', showDelay: 300 }" :disabled="!somethingSelected">
             <AddHandleTop/>
           </Button>
 
-          <Button iconOnly style="margin-left: 10px" variant="text" severity="secondary">
+          <Button iconOnly style="margin-left: 10px" variant="text" severity="secondary" v-tooltip.bottom="{ value: 'Add right handle', showDelay: 300 }" :disabled="!somethingSelected">
             <AddHandleRight/>
           </Button>
 
-          <Button iconOnly style="margin-left: 10px" variant="text" severity="secondary">
+          <Button iconOnly style="margin-left: 10px" variant="text" severity="secondary" v-tooltip.bottom="{ value: 'Add bottom handle', showDelay: 300 }" :disabled="!somethingSelected">
             <AddHandleBottom/>
           </Button>
 
@@ -804,6 +810,7 @@ const currentMatchIndex = ref(0)
 
 const allNodeNames = computed(() => nodes.value.map((n) => n.data.name))
 const somethingAvailable = computed(() => nodes.value.length > 0)
+const somethingSelected = computed(() => getSelectedNodes.value.length > 0)
 
 const importOptions = computed(() => [
   {

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -342,7 +342,7 @@
     v-model="instanceEditorDialogVisible"
     :id="currentEditingNode?.id"
     :initial-name="currentEditingNode?.name"
-    :math-ref="currentEditingNode?.mathRef || ''"
+    :math-ref="currentEditingNode?.mathRef"
     :variables="currentEditingNode?.variables"
     :initial-ports="currentEditingNode?.ports"
     :existing-names="allNodeNames"

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -264,6 +264,7 @@
                 @open-port-editor-dialog="onOpenPortEditorDialog"
                 @open-cellml-editor-dialog="onOpenCellMLEditorDialog"
                 @open-parameter-editor-dialog="onOpenParameterEditorDialog"
+                @open-instance-editor="onOpenInstanceEditorDialog"
                 @open-context-menu="onNodeContextMenu"
                 :ref="(el) => (nodeRefs[props.id] = el)"
               />
@@ -279,6 +280,30 @@
 
   <!-- PrimeVue Confirmation Dialog Service component -->
   <ConfirmDialog />
+
+  <InstanceEditorDialog
+    v-model="instanceEditorDialogVisible"
+    :id="currentEditingNode?.id"
+    :initial-name="currentEditingNode?.name"
+    :math-ref="currentEditingNode?.mathRef || ''"
+    :variables="currentEditingNode?.variables"
+    :initial-ports="currentEditingNode?.ports"
+    :existing-names="allNodeNames"
+    :default-tab="instanceEditorDefaultTab"
+    @confirm="onInstanceEditConfirm"
+  />
+
+  const props = defineProps({
+  modelValue: { type: Boolean, default: false },
+  id: { type: String, required: true },
+  initialName: { type: String, default: '' },
+  mathRef: { type: String, required: true },
+  variables: { type: Array, default: () => [] },
+  initialPorts: { type: Array, default: () => [] },
+  existingNames: { type: Array, default: () => [] },
+  defaultTab: { type: String, default: 'parameters' }, // 'parameters' or 'ports'
+})
+
 
   <PortEditorDialog
     v-model="portEditorDialogVisible"
@@ -442,6 +467,7 @@ import {
 import CellMLEditorDialog from '../components/CellMLEditorDialog.vue'
 import ParameterEditorDialog from '../components/ParameterEditorDialog.vue'
 import PortEditorDialog from '../components/PortEditorDialog.vue'
+import InstanceEditorDialog from '../components/InstanceEditorDialog.vue'
 import CellMLIcon from '../components/icons/CellMLIcon.vue'
 
 const workspaceFileInput = ref(null)
@@ -495,7 +521,8 @@ const dialogVisible = computed(() => {
     exportDialogVisible.value ||
     replacementDialogVisible.value ||
     macroBuilderDialogVisible.value ||
-    edgeConnectionDialogVisible.value
+    edgeConnectionDialogVisible.value ||
+    instanceEditorDialogVisible.value
   )
 })
 
@@ -722,6 +749,8 @@ const libraryStore = useLibraryStore()
 
 const libcellmlReadyPromise = inject('$libcellml_ready')
 const libcellml = inject('$libcellml')
+const instanceEditorDefaultTab = ref('parameters')
+const instanceEditorDialogVisible = ref(false)
 const parameterEditorDialogVisible = ref(false)
 const portEditorDialogVisible = ref(false)
 const cellMLEditorDialogVisible = ref(false)
@@ -1604,6 +1633,14 @@ function onOpenParameterEditorDialog(eventPayload) {
   parameterEditorDialogVisible.value = true
 }
 
+function onOpenInstanceEditorDialog(eventPayload, tab = 'parameters') {
+  currentEditingNode.value = {
+    ...eventPayload,
+  }
+  instanceEditorDefaultTab.value = tab
+  instanceEditorDialogVisible.value = true
+}
+
 function filterConfig(config, validPortNames, validVariableNames, updatedModule) {
   const portFields = ['entrance_ports', 'exit_ports', 'general_ports']
   portFields.forEach((field) => {
@@ -1759,6 +1796,14 @@ function recomputeEdgeCouplings(nodeId) {
       ),
     }
   })
+}
+
+async function onInstanceEditConfirm(updatedData) {
+  const { id } = currentEditingNode.value
+  if (!id) return
+
+  updateNodeData(id, updatedData)
+  recomputeEdgeCouplings(id)
 }
 
 async function onPortEditConfirm(updatedData) {

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -1795,7 +1795,7 @@ async function onInstanceEditConfirm(updatedData) {
     siblings: updatedData.siblings
   }
 
-  updateNodeData(updatedData.id, {variables: updatedData.variables, ports: updatedData.ports})
+  updateNodeData(updatedData.id, {name: updatedData.name, variables: updatedData.variables, ports: updatedData.ports})
   await handleCellMLSave(saveData)
 }
 

--- a/src/views/WorkspaceArea.vue
+++ b/src/views/WorkspaceArea.vue
@@ -1787,11 +1787,16 @@ function recomputeEdgeCouplings(nodeId) {
 }
 
 async function onInstanceEditConfirm(updatedData) {
-  const { id } = currentEditingNode.value
-  if (!id) return
+  const saveData = {
+    id: updatedData.id,
+    updateAll: updatedData.updateAll,
+    mathRef: updatedData.mathRef,
+    math: updatedData.math,
+    siblings: updatedData.siblings
+  }
 
-  updateNodeData(id, updatedData)
-  recomputeEdgeCouplings(id)
+  updateNodeData(updatedData.id, {variables: updatedData.variables, ports: updatedData.ports})
+  await handleCellMLSave(saveData)
 }
 
 async function onPortEditConfirm(updatedData) {


### PR DESCRIPTION
The right pane (parameters and ports) is collapsible, users can change the font size in the cellml text editor, the equation preview should now properly scale (tested with some gnarly equations in the heart input module), and users can now choose to overwrite math references with a confirmation dialog. Due to the amount of information displayed, I've introduced a minimum window size that triggers an overlay prompting the user to make the window larger if too small.

I haven't introduced the concept of Save As yet, but we can create an issue to do this in the future.

Have a play and see what you think!

Resolves #251. 
Resolves #412 (now use Ctrl + Enter for confirm shortcut and prevent Ctrl + S from triggering save action).