### PR TITLE
Add history to port autoupdate

### DIFF
--- a/src/components/CellMLTextEditor.vue
+++ b/src/components/CellMLTextEditor.vue
@@ -55,6 +55,7 @@ import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { Codemirror } from 'vue-codemirror'
 import { basicSetup } from 'codemirror'
 import { keymap } from '@codemirror/view'
+import { Prec } from '@codemirror/state'
 import { oneDark } from '@codemirror/theme-one-dark' 
 import 'katex/dist/katex.min.css'
 
@@ -72,7 +73,11 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['update:code', 'save', 'ready'])
+const emit = defineEmits(['update:code', 'save', 'ready', 'undo', 'redo'])
+
+// When true, the next `cellmlText` change came from setText() (an app-level
+// undo/redo replay), not a user keystroke
+let applyingExternalText = false
 
 const generator = new CellMLTextGenerator()
 const parser = new CellMLTextParser()
@@ -136,7 +141,11 @@ const checkDarkMode = () => {
   isDarkMode.value = document.documentElement.classList.contains('p-dark')
 }
 
+let cmView = null
+
 const handleStateUpdate = (viewUpdate) => {
+  cmView = viewUpdate.view
+
   if (viewUpdate.selectionSet || viewUpdate.docChanged) {
     const state = viewUpdate.state
     const pos = state.selection.main.head
@@ -156,9 +165,36 @@ const shiftSpaceKeymap = keymap.of([
   },
 ])
 
+// Intercept undo/redo ahead of basicSetup's own historyKeymap (Mod-z / Mod-Shift-z / Mod-y)
+const appHistoryKeymap = Prec.highest(
+  keymap.of([
+    {
+      key: 'Mod-z',
+      run: () => {
+        emit('undo')
+        return true
+      },
+    },
+    {
+      key: 'Mod-Shift-z',
+      run: () => {
+        emit('redo')
+        return true
+      },
+    },
+    {
+      key: 'Mod-y',
+      run: () => {
+        emit('redo')
+        return true
+      },
+    },
+  ])
+)
+
 // Dynamically inject theme extensions based on light vs. dark mode
 const extensions = computed(() => {
-  const base = [basicSetup, cellml(), shiftSpaceKeymap]
+  const base = [basicSetup, cellml(), shiftSpaceKeymap, appHistoryKeymap]
   return isDarkMode.value ? [...base, oneDark] : base
 })
 
@@ -246,22 +282,88 @@ const handleSave = () => {
 }
 
 watch(cellmlText, (newText) => {
+  if (applyingExternalText) return
+
   if (debouncer) clearTimeout(debouncer)
   debouncer = setTimeout(async () => {
     try {
       const parsed = parser.parse(newText)
       errors.value = parsed.errors
-      if (errors.value.length === 0 && parsed.xml) {
+      const valid = errors.value.length === 0 && !!parsed.xml
+
+      if (valid) {
         currentDoc = parser['doc']
-        emit('update:code', parsed.xml)
+      }
+
+      emit('update:code', valid ? parsed.xml : null, newText, valid)
+
+      if (valid) {
         await nextTick()
         updatePreview()
       }
     } catch (e) {
-      // Do nothing for invalid syntax while typing.
+      // Parse threw outright - still emit so undo has a text snapshot.
+      emit('update:code', null, newText, false)
     }
   }, 500)
 })
+
+async function setText(newText) {
+  if (debouncer) {
+    clearTimeout(debouncer)
+    debouncer = null
+  }
+
+  applyingExternalText = true
+
+  const oldText = cellmlText.value
+
+  if (cmView && oldText !== newText) {
+    const maxPrefix = Math.min(oldText.length, newText.length)
+    let prefixLen = 0
+    while (prefixLen < maxPrefix && oldText[prefixLen] === newText[prefixLen]) {
+      prefixLen++
+    }
+
+    const maxSuffix = Math.min(oldText.length, newText.length) - prefixLen
+    let suffixLen = 0
+    while (
+      suffixLen < maxSuffix &&
+      oldText[oldText.length - 1 - suffixLen] === newText[newText.length - 1 - suffixLen]
+    ) {
+      suffixLen++
+    }
+
+    const from = prefixLen
+    const to = oldText.length - suffixLen
+    const insert = newText.slice(prefixLen, newText.length - suffixLen)
+
+    cmView.dispatch({
+      changes: { from, to, insert },
+      selection: { anchor: from + insert.length },
+    })
+  } else {
+    // No view yet (shouldn't normally happen) - fall back to a full replace.
+    cellmlText.value = newText
+  }
+
+  await nextTick()
+  applyingExternalText = false
+
+  try {
+    const parsed = parser.parse(newText)
+    errors.value = parsed.errors
+    if (errors.value.length === 0 && parsed.xml) {
+      currentDoc = parser['doc']
+      await nextTick()
+      updatePreview()
+    }
+  } catch (e) {
+    // Do nothing for invalid syntax.
+  }
+}
+
+defineExpose({ setText })
 
 onMounted(() => {
   checkDarkMode()
@@ -274,7 +376,7 @@ onMounted(() => {
     if (errors.value.length === 0 && parsed.xml) {
       currentDoc = parser['doc']
       updatePreview()
-      emit('ready', parsed.xml)
+      emit('ready', parsed.xml, cellmlText.value)
     }
   } catch (e) {
     // Do nothing for initial syntax load

--- a/src/components/InstanceEditorDialog.vue
+++ b/src/components/InstanceEditorDialog.vue
@@ -376,6 +376,7 @@ import Tag from 'primevue/tag'
 
 import CellMLTextEditor from './CellMLTextEditor.vue'
 import { useLibraryStore } from '../stores/libraryStore'
+import { useFlowHistoryStore } from '../stores/historyStore'
 import { useGtm } from '../composables/useGtm'
 import { useConfirmDialog } from '../composables/useConfirmDialog'
 
@@ -400,6 +401,8 @@ const props = defineProps({
 const emit = defineEmits(['update:modelValue', 'confirm'])
 
 const store = useLibraryStore()
+const history = useFlowHistoryStore()
+
 const { trackEvent } = useGtm()
 const { nodes } = useVueFlow()
 const { alert, confirm } = useConfirmDialog()
@@ -663,7 +666,20 @@ function reconcileStagedState(newCode) {
 
   editablePorts.value.forEach((port) => {
     if (Array.isArray(port.variables)) {
-      port.variables = port.variables.filter((varName) => validVarNames.has(varName))
+      const portVars = port.variables
+      const removed = port.variables.filter((varName) => !validVarNames.has(varName))
+
+      if (removed.length > 0) {
+        history.executeAndAddCommand({
+          type: 'remove-variable-from-port',
+          undo: async () => {
+            port.variables = portVars
+          },
+          redo: async () => {
+            port.variables = port.variables.filter((varName) => validVarNames.has(varName))
+          },
+        })
+      }
     }
   })
 }

--- a/src/components/InstanceEditorDialog.vue
+++ b/src/components/InstanceEditorDialog.vue
@@ -36,11 +36,14 @@
       <div class="pane left-pane" :style="leftPaneStyle" :class="{ 'left-pane--collapsed': rightCollapsed }">
         <div class="editor-wrapper">
           <CellMLTextEditor
+            ref="cellmlEditorRef"
             :key="mathRef"
             :model-value="currentModel"
             @update:code="handleCodeUpdate"
             @ready="handleEditorReady"
             @save="handleSave"
+            @undo="handleEditorUndo"
+            @redo="handleEditorRedo"
           />
         </div>
       </div>
@@ -352,7 +355,6 @@
 <script setup>
 import { ref, computed, watch, onBeforeUnmount, onMounted, onUnmounted, nextTick } from 'vue'
 import { useVueFlow } from '@vue-flow/core'
-import { useDebounceFn } from '@vueuse/core'
 
 import Button from 'primevue/button'
 import Checkbox from 'primevue/checkbox'
@@ -412,7 +414,8 @@ const loading = ref(false)
 const activeTab = ref('parameters')
 
 // CellML State
-const currentModel = ref('')
+const currentModel = ref('')       // parsed XML representation - used for variable extraction, save, etc.
+const currentCellmlText = ref('')  // raw CellML source text - what the editor actually displays
 const originalModel = ref('')
 const applyToAll = ref(false)
 
@@ -433,6 +436,9 @@ const sortOrder = ref(1)
 // Port & Instance State
 const editableName = ref('')
 const editablePorts = ref([])
+
+// Ref to the CellML editor, used to imperatively replay text during undo/redo
+const cellmlEditorRef = ref(null)
 
 // ── Split / Collapse State ──────────────────────────────────────────────────
 const SPLIT_STORAGE_KEY = 'instanceEditorDialog.leftPanePercent'
@@ -644,15 +650,20 @@ watch(
   }
 )
 
-function reconcileStagedState(newCode) {
+async function reconcileStagedState(newCode, newRawText) {
   const extractedVariables = extractVariablesFromMath(newCode)
   if (!extractedVariables) return
+
+  const previousCode = currentModel.value
+  const previousRawText = currentCellmlText.value
+  if (previousCode === newCode) return
 
   const validVarNames = new Set(extractedVariables.map((v) => v.name))
 
   const currentMap = new Map(parameterRows.value.map((row) => [row.name, row]))
+  const previousParameterRows = parameterRows.value
 
-  parameterRows.value = extractedVariables.map((variable) => {
+  const newParameterRows = extractedVariables.map((variable) => {
     const existing = currentMap.get(variable.name)
 
     return {
@@ -664,39 +675,93 @@ function reconcileStagedState(newCode) {
     }
   })
 
-  editablePorts.value.forEach((port) => {
-    if (Array.isArray(port.variables)) {
-      const portVars = port.variables
-      const removed = port.variables.filter((varName) => !validVarNames.has(varName))
+  history.startBatch()
 
-      if (removed.length > 0) {
-        history.executeAndAddCommand({
-          type: 'remove-variable-from-port',
-          undo: async () => {
-            port.variables = portVars
-          },
-          redo: async () => {
-            port.variables = port.variables.filter((varName) => validVarNames.has(varName))
-          },
-        })
-      }
-    }
+  await history.executeAndAddCommand({
+    type: 'update-cellml-code',
+    undo: async () => {
+      currentModel.value = previousCode
+      currentCellmlText.value = previousRawText
+      await cellmlEditorRef.value?.setText(previousRawText)
+    },
+    redo: async () => {
+      currentModel.value = newCode
+      currentCellmlText.value = newRawText
+      await cellmlEditorRef.value?.setText(newRawText)
+    },
+  })
+
+  await history.executeAndAddCommand({
+    type: 'update-parameter-rows',
+    undo: async () => {
+      parameterRows.value = previousParameterRows
+    },
+    redo: async () => {
+      parameterRows.value = newParameterRows
+    },
+  })
+
+  for (const port of editablePorts.value) {
+    if (!Array.isArray(port.variables)) continue
+
+    const portVars = port.variables
+    const removed = portVars.filter((varName) => !validVarNames.has(varName))
+    if (removed.length === 0) continue
+
+    await history.executeAndAddCommand({
+      type: 'remove-variable-from-port',
+      undo: async () => {
+        port.variables = portVars
+      },
+      redo: async () => {
+        port.variables = port.variables.filter((varName) => validVarNames.has(varName))
+      },
+    })
+  }
+
+  history.endBatch()
+}
+
+function handleCodeUpdate(newCode, rawText, isValid) {
+  if (isValid) {
+    reconcileStagedState(newCode, rawText)
+  } else {
+    trackRawTextOnly(rawText)
+  }
+}
+
+async function trackRawTextOnly(rawText) {
+  const previousRawText = currentCellmlText.value
+  if (previousRawText === rawText) return
+
+  await history.executeAndAddCommand({
+    type: 'update-cellml-text-only',
+    undo: async () => {
+      currentCellmlText.value = previousRawText
+      await cellmlEditorRef.value?.setText(previousRawText)
+    },
+    redo: async () => {
+      currentCellmlText.value = rawText
+      await cellmlEditorRef.value?.setText(rawText)
+    },
   })
 }
 
-const debouncedReconcile = useDebounceFn((code) => {
-  reconcileStagedState(code)
-}, 300)
-
-function handleCodeUpdate(newCode) {
-  currentModel.value = newCode
-  debouncedReconcile(newCode)
+async function handleEditorUndo() {
+  if (!history.canUndo) return
+  await history.undo()
 }
 
-function handleEditorReady(canonicalMath) {
+async function handleEditorRedo() {
+  if (!history.canRedo) return
+  await history.redo()
+}
+
+function handleEditorReady(canonicalMath, rawText) {
   void isDirty.value
   currentModel.value = canonicalMath
   originalModel.value = canonicalMath
+  currentCellmlText.value = rawText ?? currentCellmlText.value
 }
 
 function sortParameterRows(field = 'type', order = 1) {

--- a/src/components/InstanceEditorDialog.vue
+++ b/src/components/InstanceEditorDialog.vue
@@ -103,23 +103,21 @@
               <div class="parameters-tab-body">
                 <div class="toolbar-container">
                   <div class="search-group">
-                    <div class="search-input-wrapper">
-                      <InputText
-                        v-model="searchQuery"
-                        size="small"
-                        :placeholder="`Search by ${searchColumn}...`"
-                        class="search-input"
-                      />
-                      <Button
-                        v-if="searchQuery"
-                        icon="pi pi-times"
-                        text
-                        rounded
-                        severity="secondary"
-                        size="small"
-                        class="clear-search-btn"
-                        @click="searchQuery = ''"
-                      />
+                    <div class="search-input-wrapper flex-1">
+                      <IconField class="w-full">
+                        <InputIcon class="pi pi-search" />
+                        <InputText
+                          v-model="searchQuery"
+                          class="w-full"
+                          size="small"
+                          :placeholder="`Search by ${searchColumn}...`"
+                        />
+                        <InputIcon
+                          v-if="searchQuery"
+                          class="clear-search-btn pi pi-times-circle"
+                          @click="searchQuery = ''"
+                        />
+                      </IconField>
                     </div>
                     <Select
                       v-model="searchColumn"
@@ -364,6 +362,8 @@ import Dialog from 'primevue/dialog'
 import Divider from 'primevue/divider'
 import InputNumber from 'primevue/inputnumber'
 import InputText from 'primevue/inputtext'
+import InputIcon from 'primevue/inputicon'
+import IconField from 'primevue/iconfield'
 import ProgressSpinner from 'primevue/progressspinner'
 import Select from 'primevue/select'
 import MultiSelect from 'primevue/multiselect'
@@ -1154,21 +1154,6 @@ async function handleSave() {
 
 .search-input-wrapper {
   position: relative;
-  display: flex;
-  align-items: center;
-  flex: 1 1 160px;
-  min-width: 120px;
-}
-
-.search-input-wrapper :deep(.p-inputtext) {
-  width: 100%;
-}
-
-.clear-search-btn {
-  position: absolute;
-  right: 2px;
-  width: 1.25rem !important;
-  height: 1.25rem !important;
 }
 
 .bulk-controls {


### PR DESCRIPTION
Resolves #515 

Ended up being huge headache to get this working how I wanted. We now bypass the codemirror history tracking to have a common trigger for port variable definitions. Also snuck in a cheeky improvement to the parameter search bar to align it with other search bars (maybe we should create a search bar component given how many we use...)

Worth having a play and seeing what you think.