### PR TITLE
Reduce sim steps with constant

### DIFF
--- a/src/services/export/simulation.js
+++ b/src/services/export/simulation.js
@@ -33,7 +33,7 @@ export function buildSimulationJson(plotConfig, parameterScan, supplementalData)
   })
 }
 
-const SIM_STEPS = 30
+export const SIM_STEPS = 30
 
 // input: one entry per parameter-scan selection. id/name are both just the
 // constant's own name (per spec: "id and name can just be the variable name").

--- a/src/services/export/simulation.js
+++ b/src/services/export/simulation.js
@@ -33,11 +33,13 @@ export function buildSimulationJson(plotConfig, parameterScan, supplementalData)
   })
 }
 
+const SIM_STEPS = 30
+
 // input: one entry per parameter-scan selection. id/name are both just the
 // constant's own name (per spec: "id and name can just be the variable name").
 function buildInput(scanSelections) {
   return scanSelections.map((sel) => {
-    const stepValue = (sel.max - sel.min) / 100
+    const stepValue = (sel.max - sel.min) / SIM_STEPS
     return {
       id: `id__${sel.nodeName}__${sel.parameterName}`,
       name: sel.parameterName,

--- a/tests/vitest/services/compress.test.js
+++ b/tests/vitest/services/compress.test.js
@@ -2,6 +2,7 @@ import JSZip from 'jszip'
 import { describe, expect, it } from 'vitest'
 
 import { generateOmexArchive } from '../../../src/services/compress.js'
+import { SIM_STEPS } from '../../../src/services/export/simulation.js'
 
 async function readArchive(blob) {
   return JSZip.loadAsync(await blob.arrayBuffer())
@@ -104,7 +105,7 @@ describe('generateOmexArchive', () => {
         defaultValue: 1,
         minimumValue: 0.1,
         maximumValue: 10,
-        stepValue: 0.099,
+        stepValue: 9.9/SIM_STEPS,
       },
     ])
 


### PR DESCRIPTION
Currently appears that simulations are being endlessly added to a queue in open COR. Reducing the slider's resolution makes it easier to move it around without the simulation blowing up. Shouldn't be necessary once https://github.com/opencor/webapp/issues/556 is resolved.